### PR TITLE
Refactor runner

### DIFF
--- a/src/eko/runner.py
+++ b/src/eko/runner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""This file contains the main application class of eko."""
+"""Main application class of eko."""
 import copy
 import logging
 from typing import Optional
@@ -102,36 +102,5 @@ o888ooooood8 o888o  o888o     `Y8bood8P'
         # add all operators
         for final_scale, op in self.op_grid.compute().items():
             self.out[float(final_scale)] = Operator.from_dict(op)
-
-        def similar_to_none(name: str) -> Optional[np.ndarray]:
-            grid = self.post_process[name]
-
-            default = self.out.xgrid.grid if "grid" in name else self.out.rotations.pids
-            if grid is None or (
-                len(grid) == default.size and np.allclose(grid, default, atol=1e-12)
-            ):
-                return None
-
-            return np.array(grid)
-
-        # reshape xgrid
-        inputgrid = similar_to_none("inputgrid")
-        targetgrid = similar_to_none("targetgrid")
-        if inputgrid is not None or targetgrid is not None:
-            if inputgrid is not None:
-                inputgrid = interpolation.XGrid(inputgrid)
-            if targetgrid is not None:
-                targetgrid = interpolation.XGrid(targetgrid)
-            manipulate.xgrid_reshape(
-                self.out, targetgrid=targetgrid, inputgrid=inputgrid
-            )
-
-        # reshape flavors
-        inputpids = similar_to_none("inputpids")
-        targetpids = similar_to_none("targetpids")
-        if inputpids is not None or targetpids is not None:
-            manipulate.flavor_reshape(
-                self.out, targetpids=targetpids, inputpids=inputpids
-            )
 
         return copy.deepcopy(self.out)

--- a/src/eko/runner.py
+++ b/src/eko/runner.py
@@ -75,13 +75,6 @@ o888ooooood8 o888o  o888o     `Y8bood8P'
         # setup operator grid
         self.op_grid = OperatorGrid.from_dict(new_theory, new_operators, tc, sc, bfd)
 
-        # save bases manipulations for a post processing step
-        rot = operators_card.get("rotations", {})
-        self.post_process = {}
-        for key in ("inputgrid", "targetgrid", "inputpids", "targetpids"):
-            self.post_process[key] = rot.get(key, None)
-            new_operators["rotations"][key] = None
-
         self.out = EKO.new(theory=theory_card, operator=new_operators)
 
     def get_output(self) -> EKO:

--- a/tests/eko/test_runner.py
+++ b/tests/eko/test_runner.py
@@ -78,8 +78,14 @@ def test_targetgrid():
     oc["rotations"]["targetgrid"] = tgrid
     r = eko.runner.Runner(tc, oc)
     o = r.get_output()
+    # We are testing if (as expected) the runner ignores inputgrid and targetgrid.
+    actual_grid = oc["rotations"]["xgrid"]
     check_shapes(
-        o, eko.interpolation.XGrid(tgrid), eko.interpolation.XGrid(igrid), tc, oc
+        o,
+        eko.interpolation.XGrid(actual_grid),
+        eko.interpolation.XGrid(actual_grid),
+        tc,
+        oc,
     )
     # check actual value
     np.testing.assert_allclose(o.rotations.targetgrid.raw, tgrid)
@@ -95,8 +101,8 @@ def test_rotate_pids():
     o = r.get_output()
     check_shapes(o, o.xgrid, o.xgrid, tc, oc)
     # check actual values
-    assert (o.rotations.targetpids == [0] * 14).all()
-    assert (o.rotations.inputpids == [0] * 14).all()
+    assert (o.rotations.targetpids == oc["rotations"]["targetpids"]).all()
+    assert (o.rotations.inputpids == oc["rotations"]["inputpids"]).all()
 
 
 def check_shapes(o, txs, ixs, theory_card, operators_card):
@@ -104,10 +110,17 @@ def check_shapes(o, txs, ixs, theory_card, operators_card):
     ipids = len(o.rotations.inputpids)
     op_shape = (tpids, len(txs), ipids, len(ixs))
 
+    op_targetgrid = operators_card["rotations"]["targetgrid"]
+    op_inputgrid = operators_card["rotations"]["inputgrid"]
     # check output = input
     np.testing.assert_allclose(o.xgrid.raw, operators_card["rotations"]["xgrid"])
-    np.testing.assert_allclose(o.rotations.targetgrid.raw, txs.raw)
-    np.testing.assert_allclose(o.rotations.inputgrid.raw, ixs.raw)
+    np.testing.assert_allclose(
+        o.rotations.targetgrid.raw,
+        op_targetgrid if op_targetgrid is not None else txs.raw,
+    )
+    np.testing.assert_allclose(
+        o.rotations.inputgrid.raw, op_inputgrid if op_inputgrid is not None else ixs.raw
+    )
     for k in ["interpolation_polynomial_degree", "interpolation_is_log"]:
         assert getattr(o.configs, k) == operators_card["configs"][k]
     np.testing.assert_allclose(o.Q02, theory_card["Q0"] ** 2)


### PR DESCRIPTION
We want to massively simplify `runnner.py`:

- In `get_output` we want to avoid the rotations: if needed they should be done afterwards. 
- In `__init__ ` we just need to skip the last part in which `targetpids`, `inputpids`, `targetgrid` and `inputgrid` are collected.
@felixhekhorn @AleCandido 