### PR TITLE
Fix struct.detached

### DIFF
--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -749,19 +749,12 @@ class EKO:
 
         """
         bases = operator["rotations"]
-        for basis in ("inputgrid", "targetgrid", "inputpids", "targetpids"):
-            if basis in bases:
-                bases[f"_{basis}"] = bases[basis]
-                del bases[basis]
         bases["pids"] = np.array(br.flavor_basis_pids)
-        for k in ("xgrid", "_inputgrid", "_targetgrid"):
-            if k in operator["rotations"]:
-                if operator["rotations"][k] is None:
-                    continue
-                bases[k] = interpolation.XGrid(
-                    operator["rotations"][k],
-                    log=operator["configs"]["interpolation_is_log"],
-                )
+        if operator["rotations"]["xgrid"] is not None:
+            bases["xgrid"] = interpolation.XGrid(
+                operator["rotations"]["xgrid"],
+                log=operator["configs"]["interpolation_is_log"],
+            )
 
         return cls(
             path=path,

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -750,16 +750,18 @@ class EKO:
         """
         bases = operator["rotations"]
         for basis in ("inputgrid", "targetgrid", "inputpids", "targetpids"):
-            bases[f"_{basis}"] = bases[basis]
-            del bases[basis]
+            if basis in bases:
+                bases[f"_{basis}"] = bases[basis]
+                del bases[basis]
         bases["pids"] = np.array(br.flavor_basis_pids)
         for k in ("xgrid", "_inputgrid", "_targetgrid"):
-            if operator["rotations"][k] is None:
-                continue
-            bases[k] = interpolation.XGrid(
-                operator["rotations"][k],
-                log=operator["configs"]["interpolation_is_log"],
-            )
+            if k in operator["rotations"]:
+                if operator["rotations"][k] is None:
+                    continue
+                bases[k] = interpolation.XGrid(
+                    operator["rotations"][k],
+                    log=operator["configs"]["interpolation_is_log"],
+                )
 
         return cls(
             path=path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,10 +67,6 @@ class FakeOutput:
             rotations=dict(
                 xgrid=xgrid,
                 pids=pids,
-                targetgrid=xgrid,
-                inputgrid=xgrid,
-                inputpids=pids,
-                targetpids=pids,
             ),
             Q0=np.sqrt(q2_ref),
             couplings=dict(),
@@ -101,10 +97,10 @@ class FakeOutput:
         for q2, op in d["Q2grid"].items():
             obj[q2] = output.struct.Operator.from_dict(op)
 
-        d["inputgrid"] = bases["inputgrid"]
-        d["targetgrid"] = bases["targetgrid"]
-        d["inputpids"] = bases["inputpids"]
-        d["targetpids"] = bases["targetpids"]
+        d["inputgrid"] = bases["xgrid"]
+        d["targetgrid"] = bases["xgrid"]
+        d["inputpids"] = bases["pids"]
+        d["targetpids"] = bases["pids"]
 
         d["interpolation_xgrid"] = bases["xgrid"]
         d["pids"] = bases["pids"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,10 @@ class FakeOutput:
         d = self.mk_dump()
         # build data
         obj = output.EKO.new(theory={}, operator=d)
+        obj.rotations._targetgrid = d["rotations"]["xgrid"]
+        obj.rotations._inputgrid = d["rotations"]["xgrid"]
+        obj.rotations._targetpids = d["rotations"]["pids"]
+        obj.rotations._inputpids = d["rotations"]["pids"]
         for q2, op in d["Q2grid"].items():
             obj[q2] = output.struct.Operator.from_dict(op)
         return obj, d


### PR DESCRIPTION
We want `output.struct.detached` to work even if the eko does not contain `inputpids`, `targetpids`, `inputgrid` and `targetgrid`, as this will be the case from now on. @felixhekhorn @AleCandido 