### PR TITLE
Output metadata

### DIFF
--- a/src/eko/compatibility.py
+++ b/src/eko/compatibility.py
@@ -41,22 +41,29 @@ def update(theory: dict, operators: Optional[dict]):
             "n_integration_cores",
         ):
             new_operators["configs"][k] = operators[k]
+            del new_operators[k]
         new_operators["rotations"] = {}
         new_operators["debug"] = {}
         for k in ("debug_skip_non_singlet", "debug_skip_singlet"):
             new_operators["debug"][k[len("debug_") :]] = operators[k]
-
+            del new_operators[k]
         max_order = operators["ev_op_max_order"]
         if isinstance(max_order, int):
             new_operators["configs"]["ev_op_max_order"] = [
                 max_order,
                 new_theory["order"][1],
             ]
+        del new_operators["ev_op_max_order"]
         new_operators["rotations"]["pids"] = operators["pids"]
+        del new_operators["pids"]
         new_operators["rotations"]["xgrid"] = operators["interpolation_xgrid"]
+        del new_operators["interpolation_xgrid"]
         for basis in ("inputgrid", "targetgrid", "inputpids", "targetpids"):
             new_operators["rotations"][f"{basis}"] = operators[basis]
+            del new_operators[basis]
         new_operators["Q0"] = new_theory["Q0"]
+        if "hash" in new_operators:
+            del new_operators["hash"]
     return new_theory, new_operators
 
 

--- a/src/eko/compatibility.py
+++ b/src/eko/compatibility.py
@@ -27,12 +27,10 @@ def update(theory: dict, operators: Optional[dict]):
     """
     new_theory = copy.deepcopy(theory)
     new_operators = copy.deepcopy(operators) if operators is not None else {}
-
     if "alphaqed" in new_theory:
         new_theory["alphaem"] = new_theory.pop("alphaqed")
     if "QED" in new_theory:
         new_theory["order"] = [new_theory.pop("PTO") + 1, new_theory.pop("QED")]
-
     if operators is not None and "configs" not in operators:
         new_operators["configs"] = {}
         for k in (
@@ -54,12 +52,11 @@ def update(theory: dict, operators: Optional[dict]):
                 max_order,
                 new_theory["order"][1],
             ]
-
+        new_operators["rotations"]["pids"] = operators["pids"]
         new_operators["rotations"]["xgrid"] = operators["interpolation_xgrid"]
         for basis in ("inputgrid", "targetgrid", "inputpids", "targetpids"):
             new_operators["rotations"][f"{basis}"] = operators[basis]
         new_operators["Q0"] = new_theory["Q0"]
-
     return new_theory, new_operators
 
 

--- a/src/eko/output/legacy.py
+++ b/src/eko/output/legacy.py
@@ -33,7 +33,6 @@ def get_raw(eko: struct.EKO, binarize: bool = True):
 
     """
     obj = eko.raw
-
     # prepare output dict
     out = {"Q2grid": {}, "eko_version": version.__version__}
     out["Q0"] = obj["Q0"]
@@ -42,8 +41,6 @@ def get_raw(eko: struct.EKO, binarize: bool = True):
         for key, value in obj[sec].items():
             if key.startswith("_"):
                 key = key[1:]
-            if "grid" in key and value is not None:
-                value = value["grid"]
             out[key] = value
 
     out["interpolation_xgrid"] = out["xgrid"]
@@ -81,10 +78,13 @@ def tocard(raw: dict) -> dict:
 
     card["rotations"] = {}
     card["rotations"]["xgrid"] = raw["interpolation_xgrid"]
+    del card["interpolation_xgrid"]
     # being an internal detail, "pids" field was often (or always) omitted
     card["rotations"]["pids"] = raw.get("pids")
+    del card["pids"]
     for basis in ("inputgrid", "targetgrid", "inputpids", "targetpids"):
         card["rotations"][basis] = raw[basis]
+        del card[basis]
 
     card["configs"] = {}
     for field in dataclasses.fields(struct.Configs):

--- a/src/eko/output/manipulate.py
+++ b/src/eko/output/manipulate.py
@@ -139,18 +139,14 @@ def flavor_reshape(
         errs = elem.error
         if targetpids is not None and inputpids is None:
             # update metadata
-            eko.update_metadata({"rotations": {"_targetpids": targetpids}})
             ops = np.einsum("ca,ajbk->cjbk", targetpids, ops)
             errs = np.einsum("ca,ajbk->cjbk", targetpids, errs)
         elif inputpids is not None and targetpids is None:
             # update metadata
-            eko.update_metadata({"rotations": {"_inputpids": inputpids}})
             ops = np.einsum("ajbk,bd->ajdk", ops, inv_inputpids)
             errs = np.einsum("ajbk,bd->ajdk", errs, inv_inputpids)
         else:
             # update metadata
-            eko.update_metadata({"rotations": {"_inputpids": inputpids}})
-            eko.update_metadata({"rotations": {"_targetpids": targetpids}})
             ops = np.einsum("ca,ajbk,bd->cjdk", targetpids, ops, inv_inputpids)
             errs = np.einsum("ca,ajbk,bd->cjdk", targetpids, errs, inv_inputpids)
         elem.operator = ops
@@ -162,8 +158,10 @@ def flavor_reshape(
     # there is no meaningful way to set them in general, after rotation
     if inputpids is not None:
         eko.rotations._inputpids = np.array([0] * len(eko.rotations.inputpids))
+        eko.update_metadata({"rotations": {"_inputpids": inputpids}})
     if targetpids is not None:
         eko.rotations._targetpids = np.array([0] * len(eko.rotations.targetpids))
+        eko.update_metadata({"rotations": {"_targetpids": targetpids}})
 
 
 def to_evol(eko: EKO, source: bool = True, target: bool = False):

--- a/src/eko/output/manipulate.py
+++ b/src/eko/output/manipulate.py
@@ -138,15 +138,12 @@ def flavor_reshape(
         ops = elem.operator
         errs = elem.error
         if targetpids is not None and inputpids is None:
-            # update metadata
             ops = np.einsum("ca,ajbk->cjbk", targetpids, ops)
             errs = np.einsum("ca,ajbk->cjbk", targetpids, errs)
         elif inputpids is not None and targetpids is None:
-            # update metadata
             ops = np.einsum("ajbk,bd->ajdk", ops, inv_inputpids)
             errs = np.einsum("ajbk,bd->ajdk", errs, inv_inputpids)
         else:
-            # update metadata
             ops = np.einsum("ca,ajbk,bd->cjdk", targetpids, ops, inv_inputpids)
             errs = np.einsum("ca,ajbk,bd->cjdk", targetpids, errs, inv_inputpids)
         elem.operator = ops
@@ -158,10 +155,10 @@ def flavor_reshape(
     # there is no meaningful way to set them in general, after rotation
     if inputpids is not None:
         eko.rotations._inputpids = np.array([0] * len(eko.rotations.inputpids))
-        eko.update_metadata({"rotations": {"_inputpids": inputpids}})
+        eko.update_metadata({"rotations": {"_inputpids": eko.rotations._inputpids}})
     if targetpids is not None:
         eko.rotations._targetpids = np.array([0] * len(eko.rotations.targetpids))
-        eko.update_metadata({"rotations": {"_targetpids": targetpids}})
+        eko.update_metadata({"rotations": {"_targetpids": eko.rotations._targetpids}})
 
 
 def to_evol(eko: EKO, source: bool = True, target: bool = False):
@@ -183,10 +180,10 @@ def to_evol(eko: EKO, source: bool = True, target: bool = False):
     flavor_reshape(eko, inputpids=inputpids, targetpids=targetpids)
     # assign pids
     if source:
-        eko.rotations._inputpids = br.evol_basis_pids
+        eko.rotations._inputpids = inputpids
         # update metadata
-        eko.update_metadata({"rotations": {"_inputpids": br.evol_basis_pids}})
+        eko.update_metadata({"rotations": {"_inputpids": inputpids}})
     if target:
-        eko.rotations._targetpids = br.evol_basis_pids
+        eko.rotations._targetpids = targetpids
         # update metadata
-        eko.update_metadata({"rotations": {"_targetpids": br.evol_basis_pids}})
+        eko.update_metadata({"rotations": {"_targetpids": targetpids}})

--- a/src/eko/output/manipulate.py
+++ b/src/eko/output/manipulate.py
@@ -61,6 +61,8 @@ def xgrid_reshape(
         )
         target_rot = b.get_interpolation(targetgrid.raw)
         eko.rotations._targetgrid = targetgrid
+        # update metadata
+        eko.update_metadata({"rotations": {"targetgrid": targetgrid}})
     if inputgrid is not None:
         b = interpolation.InterpolatorDispatcher(
             inputgrid,
@@ -69,6 +71,8 @@ def xgrid_reshape(
         )
         input_rot = b.get_interpolation(eko.rotations.inputgrid.raw)
         eko.rotations._inputgrid = inputgrid
+        # update metadata
+        eko.update_metadata({"rotations": {"inputgrid": inputgrid}})
 
     # build new grid
     for q2, elem in eko.items():
@@ -134,12 +138,19 @@ def flavor_reshape(
         ops = elem.operator
         errs = elem.error
         if targetpids is not None and inputpids is None:
+            # update metadata
+            eko.update_metadata({"rotations": {"targetpids": targetpids}})
             ops = np.einsum("ca,ajbk->cjbk", targetpids, ops)
             errs = np.einsum("ca,ajbk->cjbk", targetpids, errs)
         elif inputpids is not None and targetpids is None:
+            # update metadata
+            eko.update_metadata({"rotations": {"inputpids": inputpids}})
             ops = np.einsum("ajbk,bd->ajdk", ops, inv_inputpids)
             errs = np.einsum("ajbk,bd->ajdk", errs, inv_inputpids)
         else:
+            # update metadata
+            eko.update_metadata({"rotations": {"inputpids": inputpids}})
+            eko.update_metadata({"rotations": {"targetpids": targetpids}})
             ops = np.einsum("ca,ajbk,bd->cjdk", targetpids, ops, inv_inputpids)
             errs = np.einsum("ca,ajbk,bd->cjdk", targetpids, errs, inv_inputpids)
         elem.operator = ops
@@ -175,5 +186,9 @@ def to_evol(eko: EKO, source: bool = True, target: bool = False):
     # assign pids
     if source:
         eko.rotations._inputpids = br.evol_basis_pids
+        # update metadata
+        eko.update_metadata({"rotations": {"inputpids": inputpids}})
     if target:
         eko.rotations._targetpids = br.evol_basis_pids
+        # update metadata
+        eko.update_metadata({"rotations": {"targetpids": targetpids}})

--- a/src/eko/output/manipulate.py
+++ b/src/eko/output/manipulate.py
@@ -187,8 +187,8 @@ def to_evol(eko: EKO, source: bool = True, target: bool = False):
     if source:
         eko.rotations._inputpids = br.evol_basis_pids
         # update metadata
-        eko.update_metadata({"rotations": {"_inputpids": inputpids}})
+        eko.update_metadata({"rotations": {"_inputpids": br.evol_basis_pids}})
     if target:
         eko.rotations._targetpids = br.evol_basis_pids
         # update metadata
-        eko.update_metadata({"rotations": {"_targetpids": targetpids}})
+        eko.update_metadata({"rotations": {"_targetpids": br.evol_basis_pids}})

--- a/src/eko/output/manipulate.py
+++ b/src/eko/output/manipulate.py
@@ -62,7 +62,7 @@ def xgrid_reshape(
         target_rot = b.get_interpolation(targetgrid.raw)
         eko.rotations._targetgrid = targetgrid
         # update metadata
-        eko.update_metadata({"rotations": {"targetgrid": targetgrid}})
+        eko.update_metadata({"rotations": {"_targetgrid": targetgrid}})
     if inputgrid is not None:
         b = interpolation.InterpolatorDispatcher(
             inputgrid,
@@ -72,7 +72,7 @@ def xgrid_reshape(
         input_rot = b.get_interpolation(eko.rotations.inputgrid.raw)
         eko.rotations._inputgrid = inputgrid
         # update metadata
-        eko.update_metadata({"rotations": {"inputgrid": inputgrid}})
+        eko.update_metadata({"rotations": {"_inputgrid": inputgrid}})
 
     # build new grid
     for q2, elem in eko.items():
@@ -139,18 +139,18 @@ def flavor_reshape(
         errs = elem.error
         if targetpids is not None and inputpids is None:
             # update metadata
-            eko.update_metadata({"rotations": {"targetpids": targetpids}})
+            eko.update_metadata({"rotations": {"_targetpids": targetpids}})
             ops = np.einsum("ca,ajbk->cjbk", targetpids, ops)
             errs = np.einsum("ca,ajbk->cjbk", targetpids, errs)
         elif inputpids is not None and targetpids is None:
             # update metadata
-            eko.update_metadata({"rotations": {"inputpids": inputpids}})
+            eko.update_metadata({"rotations": {"_inputpids": inputpids}})
             ops = np.einsum("ajbk,bd->ajdk", ops, inv_inputpids)
             errs = np.einsum("ajbk,bd->ajdk", errs, inv_inputpids)
         else:
             # update metadata
-            eko.update_metadata({"rotations": {"inputpids": inputpids}})
-            eko.update_metadata({"rotations": {"targetpids": targetpids}})
+            eko.update_metadata({"rotations": {"_inputpids": inputpids}})
+            eko.update_metadata({"rotations": {"_targetpids": targetpids}})
             ops = np.einsum("ca,ajbk,bd->cjdk", targetpids, ops, inv_inputpids)
             errs = np.einsum("ca,ajbk,bd->cjdk", targetpids, errs, inv_inputpids)
         elem.operator = ops
@@ -187,8 +187,8 @@ def to_evol(eko: EKO, source: bool = True, target: bool = False):
     if source:
         eko.rotations._inputpids = br.evol_basis_pids
         # update metadata
-        eko.update_metadata({"rotations": {"inputpids": inputpids}})
+        eko.update_metadata({"rotations": {"_inputpids": inputpids}})
     if target:
         eko.rotations._targetpids = br.evol_basis_pids
         # update metadata
-        eko.update_metadata({"rotations": {"targetpids": targetpids}})
+        eko.update_metadata({"rotations": {"_targetpids": targetpids}})

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -735,7 +735,7 @@ class EKO:
         )
 
     @classmethod
-    def detached(cls, theory: dict, operator: dict, path: pathlib.Path):
+    def detached(cls, theory: dict, operator: dict, metadata: dict, path: pathlib.Path):
         """Build the in-memory object alone.
 
         Note
@@ -761,7 +761,7 @@ class EKO:
             the generated structure
 
         """
-        bases = operator["rotations"]
+        bases = metadata
         bases["pids"] = np.array(br.flavor_basis_pids)
         if operator["rotations"]["xgrid"] is not None:
             bases["xgrid"] = interpolation.XGrid(
@@ -863,8 +863,9 @@ class EKO:
 
         theory = yaml.safe_load(cls.extract(path, THEORYFILE))
         operator = yaml.safe_load(cls.extract(path, OPERATORFILE))
+        metadata = yaml.safe_load(cls.extract(path, METADATAFILE))
 
-        eko = cls.detached(theory, operator, path=path)
+        eko = cls.detached(theory, operator, metadata, path=path)
         logger.info(f"Operator loaded from path '{path}'")
         return eko
 

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -713,7 +713,7 @@ class EKO:
         yaml.safe_dump(self.metadata, stream)
         stream.seek(0)
         info = tarfile.TarInfo(name=METADATAFILE)
-        info.size = len(stream.len)
+        info.size = len(stream.tell())
         info.mtime = int(time.time())
         info.mode = 436
         with tarfile.open(self.path, "a") as tar:

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -824,10 +824,10 @@ class EKO:
             path.unlink()
         # Constructing initial metadata
         metadata = {}
-        metadata["targetgrid"] = operator["rotations"]["xgrid"]
-        metadata["inputgrid"] = operator["rotations"]["xgrid"]
-        metadata["targetpids"] = operator["rotations"]["pids"]
-        metadata["inputpids"] = operator["rotations"]["pids"]
+        metadata["_targetgrid"] = operator["rotations"]["xgrid"]
+        metadata["_inputgrid"] = operator["rotations"]["xgrid"]
+        metadata["_targetpids"] = operator["rotations"]["pids"]
+        metadata["_inputpids"] = operator["rotations"]["pids"]
         with tempfile.TemporaryDirectory() as td:
             td = pathlib.Path(td)
             cls.bootstrap(td, theory=theory, operator=operator, metadata=metadata)

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -761,13 +761,12 @@ class EKO:
             the generated structure
 
         """
-        bases = metadata
+        bases = copy.deepcopy(metadata)
         bases["pids"] = np.array(br.flavor_basis_pids)
-        if operator["rotations"]["xgrid"] is not None:
-            bases["xgrid"] = interpolation.XGrid(
-                operator["rotations"]["xgrid"],
-                log=operator["configs"]["interpolation_is_log"],
-            )
+        bases["xgrid"] = interpolation.XGrid(
+            operator["rotations"]["xgrid"],
+            log=operator["configs"]["interpolation_is_log"],
+        )
 
         return cls(
             path=path,

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -751,15 +751,15 @@ class EKO:
             to_update["rotations"][attr] = to_update["rotations"][attr].tolist()
         new_metadata = copy.deepcopy(self.metadata)
         new_metadata["rotations"].update(to_update["rotations"])
-        stream = io.StringIO()
-        yaml.safe_dump(new_metadata, stream)
-        stream.seek(0)
-        info = tarfile.TarInfo(name=METADATAFILE)
-        info.size = len(stream.getvalue())
-        info.mtime = int(time.time())
-        info.mode = 436
-        with tarfile.open(self.path, "a") as tar:
-            tar.addfile(info, fileobj=stream)
+        # stream = io.StringIO()
+        # yaml.safe_dump(new_metadata, stream)
+        # stream.seek(0)
+        # info = tarfile.TarInfo(name=METADATAFILE)
+        # info.size = len(stream.getvalue())
+        # info.mtime = int(time.time())
+        # info.mode = 436
+        # with tarfile.open(self.path, "a") as tar:
+        #    tar.addfile(info, fileobj=stream)
 
     @property
     def operator_card(self) -> dict:
@@ -889,11 +889,11 @@ class EKO:
         metadata["rotations"]["_inputgrid"] = copy.deepcopy(
             operator["rotations"]["xgrid"]
         )
-        metadata["rotations"]["_targetpids"] = copy.deepcopy(
-            operator["rotations"]["pids"]
+        metadata["rotations"]["_targetpids"] = np.array(
+            copy.deepcopy(operator["rotations"]["pids"])
         )
-        metadata["rotations"]["_inputpids"] = copy.deepcopy(
-            operator["rotations"]["pids"]
+        metadata["rotations"]["_inputpids"] = np.array(
+            copy.deepcopy(operator["rotations"]["pids"])
         )
         with tempfile.TemporaryDirectory() as td:
             td = pathlib.Path(td)

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -276,6 +276,7 @@ class Rotations(DictLike):
     @property
     def inputgrid(self) -> interpolation.XGrid:
         """Provide :math:`x`-grid expected on the input PDF."""
+        self.__post_init__()
         if self._inputgrid is None:
             return self.xgrid
         return self._inputgrid
@@ -283,6 +284,7 @@ class Rotations(DictLike):
     @property
     def targetgrid(self) -> interpolation.XGrid:
         """Provide :math:`x`-grid corresponding to the output PDF."""
+        self.__post_init__()
         if self._targetgrid is None:
             return self.xgrid
         return self._targetgrid

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -713,7 +713,7 @@ class EKO:
         yaml.safe_dump(self.metadata, stream)
         stream.seek(0)
         info = tarfile.TarInfo(name=METADATAFILE)
-        info.size = len(stream.getbuffer())
+        info.size = len(stream.len)
         info.mtime = int(time.time())
         info.mode = 436
         with tarfile.open(self.path, "a") as tar:

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -838,10 +838,18 @@ class EKO:
             path.unlink()
         # Constructing initial metadata
         metadata = dict(rotations=dict())
-        metadata["rotations"]["_targetgrid"] = operator["rotations"]["xgrid"]
-        metadata["rotations"]["_inputgrid"] = operator["rotations"]["xgrid"]
-        metadata["rotations"]["_targetpids"] = operator["rotations"]["pids"]
-        metadata["rotations"]["_inputpids"] = operator["rotations"]["pids"]
+        metadata["rotations"]["_targetgrid"] = np.array(
+            copy.deepcopy(operator["rotations"]["xgrid"])
+        )
+        metadata["rotations"]["_inputgrid"] = np.array(
+            copy.deepcopy(operator["rotations"]["xgrid"])
+        )
+        metadata["rotations"]["_targetpids"] = np.array(
+            copy.deepcopy(operator["rotations"]["pids"])
+        )
+        metadata["rotations"]["_inputpids"] = np.array(
+            copy.deepcopy(operator["rotations"]["pids"])
+        )
         with tempfile.TemporaryDirectory() as td:
             td = pathlib.Path(td)
             cls.bootstrap(td, theory=theory, operator=operator, metadata=metadata)

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -765,15 +765,15 @@ class EKO:
             to_update["rotations"][attr] = to_update["rotations"][attr].tolist()
         new_metadata = copy.deepcopy(self.metadata)
         new_metadata["rotations"].update(to_update["rotations"])
-        # stream = io.StringIO()
-        # yaml.safe_dump(new_metadata, stream)
-        # stream.seek(0)
-        # info = tarfile.TarInfo(name=METADATAFILE)
-        # info.size = len(stream.getvalue())
-        # info.mtime = int(time.time())
-        # info.mode = 436
-        # with tarfile.open(self.path, "a") as tar:
-        #    tar.addfile(info, fileobj=stream)
+        new_metadata_string = yaml.safe_dump(new_metadata).encode()
+        stream = io.BytesIO(new_metadata_string)
+        stream.seek(0)
+        info = tarfile.TarInfo(name=f"metadata.yaml")
+        info.size = len(stream.getbuffer())
+        info.mtime = int(time.time())
+        info.mode = 436
+        with tarfile.open(self.path, "a") as tar:
+            tar.addfile(info, fileobj=stream)
 
     @property
     def operator_card(self) -> dict:

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 
 THEORYFILE = "theory.yaml"
 OPERATORFILE = "operator.yaml"
+METADATAFILE = "metadata.yaml"
 RECIPESDIR = "recipes"
 PARTSDIR = "parts"
 OPERATORSDIR = "operators"
@@ -630,7 +631,7 @@ class EKO:
         return new
 
     @staticmethod
-    def bootstrap(dirpath: os.PathLike, theory: dict, operator: dict):
+    def bootstrap(dirpath: os.PathLike, theory: dict, operator: dict, metadata: dict):
         """Create directory structure.
 
         Parameters
@@ -641,11 +642,13 @@ class EKO:
             theory card to be dumped
         operator: dict
             operator card to be dumped
-
+        metadata: dict
+            metadata of the operator
         """
         dirpath = pathlib.Path(dirpath)
         (dirpath / THEORYFILE).write_text(yaml.dump(theory), encoding="utf-8")
         (dirpath / OPERATORFILE).write_text(yaml.dump(operator), encoding="utf-8")
+        (dirpath / METADATAFILE).write_test(yaml.dump(metadata), encoding="utf-8")
         (dirpath / RECIPESDIR).mkdir()
         (dirpath / PARTSDIR).mkdir()
         (dirpath / OPERATORSDIR).mkdir()
@@ -787,6 +790,8 @@ class EKO:
             the theory card
         operator : dict
             the operator card
+        metadata: dict
+            metadata of the operator
         path : os.PathLike
             the underlying path (if not provided, it is created in a temporary
             path)
@@ -807,10 +812,15 @@ class EKO:
                 )
             # delete the file created in case of temporary file
             path.unlink()
-
+        # Constructing initial metadata
+        metadata = {}
+        metadata["targetgrid"] = operator["rotations"]["xgrid"]
+        metadata["inputgrid"] = operator["rotations"]["xgrid"]
+        metadata["targetpids"] = operator["rotations"]["pids"]
+        metadata["inputpids"] = operator["rotations"]["pids"]
         with tempfile.TemporaryDirectory() as td:
             td = pathlib.Path(td)
-            cls.bootstrap(td, theory=theory, operator=operator)
+            cls.bootstrap(td, theory=theory, operator=operator, metadata=metadata)
 
             with tarfile.open(path, mode="w") as tar:
                 for element in td.glob("*"):

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -667,6 +667,8 @@ class EKO:
                     ][attr]["operator"].tolist()
             except IndexError:
                 continue
+            except TypeError:
+                continue
         for attr in operator_to_dump["Q2grid"]:
             try:
                 if isinstance(operator_to_dump["Q2grid"][attr]["error"], np.ndarray):
@@ -674,6 +676,8 @@ class EKO:
                         "Q2grid"
                     ][attr]["error"].tolist()
             except IndexError:
+                continue
+            except TypeError:
                 continue
         for attr in metadata_to_dump["rotations"]:
             if isinstance(metadata_to_dump["rotations"][attr], np.ndarray):

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -764,6 +764,8 @@ class EKO:
             the theory card
         operator : dict
             the operator card
+        metadata: dict
+            the metadata card
         path : os.PathLike
             the underlying path (it has to be a valid object, but it is not
             guaranteed, see the note)

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -697,6 +697,16 @@ class EKO:
         return self.theory
 
     @property
+    def metadata(self) -> dict:
+        """Provide metadata, retrieving from the dump."""
+        return yaml.safe_load(self.extract(self.path, METADATAFILE))
+
+    @property
+    def metadata_card(self) -> dict:
+        """Provide metadata, retrieving from the dump."""
+        return self.metadata
+
+    @property
     def operator_card(self) -> dict:
         """Provide operator card, retrieving from the dump."""
         # TODO: return `eko.runcards.OperatorCard`

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -254,7 +254,7 @@ class Rotations(DictLike):
             value = getattr(self, attr)
             if value is None:
                 continue
-            if isinstance(value, np.ndarray) or isinstance(value, list):
+            if isinstance(value, (np.ndarray, list)):
                 setattr(self, attr, interpolation.XGrid(value))
             elif not isinstance(value, interpolation.XGrid):
                 setattr(self, attr, interpolation.XGrid.load(value))

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -838,7 +838,7 @@ class EKO:
 
             shutil.rmtree(td)
 
-        eko = cls.detached(theory, operator, path=path)
+        eko = cls.detached(theory, operator, metadata, path=path)
         logger.info(f"New operator created at path '{path}'")
         return eko
 

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -777,6 +777,9 @@ class EKO:
 
         """
         bases = copy.deepcopy(metadata["rotations"])
+        # cast bases list to numpy array
+        for attr in bases:
+            bases[attr] = np.array(bases[attr])
         bases["pids"] = np.array(br.flavor_basis_pids)
         bases["xgrid"] = interpolation.XGrid(
             operator["rotations"]["xgrid"],
@@ -838,17 +841,17 @@ class EKO:
             path.unlink()
         # Constructing initial metadata
         metadata = dict(rotations=dict())
-        metadata["rotations"]["_targetgrid"] = np.array(
-            copy.deepcopy(operator["rotations"]["xgrid"])
+        metadata["rotations"]["_targetgrid"] = copy.deepcopy(
+            operator["rotations"]["xgrid"]
         )
-        metadata["rotations"]["_inputgrid"] = np.array(
-            copy.deepcopy(operator["rotations"]["xgrid"])
+        metadata["rotations"]["_inputgrid"] = copy.deepcopy(
+            operator["rotations"]["xgrid"]
         )
-        metadata["rotations"]["_targetpids"] = np.array(
-            copy.deepcopy(operator["rotations"]["pids"])
+        metadata["rotations"]["_targetpids"] = copy.deepcopy(
+            operator["rotations"]["pids"]
         )
-        metadata["rotations"]["_inputpids"] = np.array(
-            copy.deepcopy(operator["rotations"]["pids"])
+        metadata["rotations"]["_inputpids"] = copy.deepcopy(
+            operator["rotations"]["pids"]
         )
         with tempfile.TemporaryDirectory() as td:
             td = pathlib.Path(td)
@@ -857,9 +860,7 @@ class EKO:
             with tarfile.open(path, mode="w") as tar:
                 for element in td.glob("*"):
                     tar.add(element, arcname=element.name)
-
             shutil.rmtree(td)
-
         eko = cls.detached(theory, operator, metadata, path=path)
         logger.info(f"New operator created at path '{path}'")
         return eko

--- a/src/eko/output/struct.py
+++ b/src/eko/output/struct.py
@@ -648,7 +648,7 @@ class EKO:
         dirpath = pathlib.Path(dirpath)
         (dirpath / THEORYFILE).write_text(yaml.dump(theory), encoding="utf-8")
         (dirpath / OPERATORFILE).write_text(yaml.dump(operator), encoding="utf-8")
-        (dirpath / METADATAFILE).write_test(yaml.dump(metadata), encoding="utf-8")
+        (dirpath / METADATAFILE).write_text(yaml.dump(metadata), encoding="utf-8")
         (dirpath / RECIPESDIR).mkdir()
         (dirpath / PARTSDIR).mkdir()
         (dirpath / OPERATORSDIR).mkdir()

--- a/src/ekobox/evol_pdf.py
+++ b/src/ekobox/evol_pdf.py
@@ -6,6 +6,7 @@ import numpy as np
 import eko
 import eko.output.legacy
 from eko import basis_rotation as br
+from eko import compatibility
 from ekomark import apply
 
 from . import genpdf, info_file
@@ -45,6 +46,7 @@ def evolve_pdfs(
     info_update : dict
         dict of info to add or update to default info file
     """
+    # update op and th cards
     eko_output = None
     if path is not None:
         my_path = pathlib.Path(path)
@@ -63,7 +65,7 @@ def evolve_pdfs(
         evolved_PDF_list.append(apply.apply_pdf(eko_output, initial_PDF, targetgrid))
 
     if targetgrid is None:
-        targetgrid = operators_card["interpolation_xgrid"]
+        targetgrid = operators_card["rotations"]["xgrid"]
     if info_update is None:
         info_update = {}
     info_update["XMin"] = targetgrid[0]
@@ -111,4 +113,7 @@ def ekofileid(theory_card, operators_card):
     str
         file name
     """
-    return f"o{operators_card['hash'][:6]}_t{theory_card['hash'][:6]}.tar"
+    try:
+        return f"o{operators_card['hash'][:6]}_t{theory_card['hash'][:6]}.tar"
+    except KeyError:
+        return "o000000_t000000.tar"

--- a/src/ekobox/info_file.py
+++ b/src/ekobox/info_file.py
@@ -32,8 +32,8 @@ def build(theory_card, operators_card, num_members, info_update):
     template_info["NumFlavors"] = 14
     template_info["Flavors"] = [-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 21, 22]
     # TODO actually point to input grid
-    template_info["XMin"] = operators_card["interpolation_xgrid"][0]
-    template_info["XMax"] = operators_card["interpolation_xgrid"][-1]
+    template_info["XMin"] = operators_card["rotations"]["xgrid"][0]
+    template_info["XMax"] = operators_card["rotations"]["xgrid"][-1]
     template_info["NumMembers"] = num_members
     try:
         template_info["OrderQCD"] = theory_card["PTO"]

--- a/src/ekobox/info_file.py
+++ b/src/ekobox/info_file.py
@@ -35,7 +35,10 @@ def build(theory_card, operators_card, num_members, info_update):
     template_info["XMin"] = operators_card["interpolation_xgrid"][0]
     template_info["XMax"] = operators_card["interpolation_xgrid"][-1]
     template_info["NumMembers"] = num_members
-    template_info["OrderQCD"] = theory_card["PTO"]
+    try:
+        template_info["OrderQCD"] = theory_card["PTO"]
+    except KeyError:
+        template_info["OrderQCD"] = theory_card["order"][0]
     template_info["QMin"] = round(math.sqrt(operators_card["Q2grid"][0]), 4)
     template_info["QMax"] = round(math.sqrt(operators_card["Q2grid"][-1]), 4)
     template_info["MZ"] = theory_card["MZ"]
@@ -46,6 +49,9 @@ def build(theory_card, operators_card, num_members, info_update):
     template_info["MBottom"] = theory_card["mb"]
     template_info["MTop"] = theory_card["mt"]
     template_info["AlphaS_MZ"] = theory_card["alphas"]
-    template_info["AlphaS_OrderQCD"] = theory_card["PTO"]
+    try:
+        template_info["AlphaS_OrderQCD"] = theory_card["PTO"]
+    except KeyError:
+        template_info["AlphaS_OrderQCD"] = theory_card["order"][0]
     # NB: Maybe I need the actual operator to obtain AlphaS_Qs
     return template_info

--- a/src/ekobox/operators_card.py
+++ b/src/ekobox/operators_card.py
@@ -32,7 +32,7 @@ def generate(Q2grid, update=None, name=None):
     # Constructing the dictionary with some default value
     def_op = copy.deepcopy(operators.default_card)
     # Adding the mandatory inputs
-    def_op["pids"] = br.flavor_basis_pids
+    def_op["pids"] = list(br.flavor_basis_pids)
     def_op["Q2grid"] = Q2grid
     if isinstance(update, dict):
         for k in update.keys():

--- a/src/ekobox/operators_card.py
+++ b/src/ekobox/operators_card.py
@@ -4,6 +4,7 @@ import copy
 import yaml
 from banana.data import sql
 
+from eko import basis_rotation as br
 from ekomark.data import operators
 
 
@@ -31,6 +32,7 @@ def generate(Q2grid, update=None, name=None):
     # Constructing the dictionary with some default value
     def_op = copy.deepcopy(operators.default_card)
     # Adding the mandatory inputs
+    def_op["pids"] = br.flavor_basis_pids
     def_op["Q2grid"] = Q2grid
     if isinstance(update, dict):
         for k in update.keys():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,6 @@ class FakeOutput:
                 pids=pids,
             ),
             Q0=np.sqrt(q2_ref),
-            couplings=dict(),
             configs=dict(
                 ev_op_max_order=1,
                 ev_op_iterations=1,

--- a/tests/eko/test_output.py
+++ b/tests/eko/test_output.py
@@ -229,6 +229,7 @@ class TestManipulate:
                 inputgrid=xgrid,
                 inputpids=br.flavor_basis_pids,
                 targetpids=br.flavor_basis_pids,
+                pids=br.flavor_basis_pids,
             ),
             configs=dict(
                 interpolation_polynomial_degree=interpolation_polynomial_degree,

--- a/tests/eko/test_output.py
+++ b/tests/eko/test_output.py
@@ -250,7 +250,9 @@ class TestManipulate:
         chk_keys(o00.raw, o11.raw)
 
         # check the input rotated one
-        np.testing.assert_allclose(o01.rotations.inputpids, br.evol_basis_pids)
+        np.testing.assert_allclose(
+            o01.rotations.inputpids, br.rotate_flavor_to_evolution
+        )
         np.testing.assert_allclose(o01.rotations.targetpids, br.flavor_basis_pids)
         # rotate also target
         manipulate.to_evol(o01, False, True)
@@ -258,7 +260,9 @@ class TestManipulate:
         chk_keys(o00.raw, o01.raw)
         # check the target rotated one
         np.testing.assert_allclose(o10.rotations.inputpids, br.flavor_basis_pids)
-        np.testing.assert_allclose(o10.rotations.targetpids, br.evol_basis_pids)
+        np.testing.assert_allclose(
+            o10.rotations.targetpids, br.rotate_flavor_to_evolution
+        )
         # rotate also input
         manipulate.to_evol(o10)
         np.testing.assert_allclose(o10[q2_out].operator, o11[q2_out].operator)

--- a/tests/eko/test_output.py
+++ b/tests/eko/test_output.py
@@ -33,7 +33,6 @@ class TestLegacy:
         o1, fake_card = fake_legacy
         for q2, op in fake_card["Q2grid"].items():
             o1[q2] = output.Operator.from_dict(op)
-
         # test streams
         stream = io.StringIO()
         legacy.dump_yaml(o1, stream)

--- a/tests/eko/test_output_struct.py
+++ b/tests/eko/test_output_struct.py
@@ -130,7 +130,9 @@ class TestEKO:
     def _default_cards(self):
         t = tc.generate(0, 1.0)
         o = oc.generate([10.0])
-        return compatibility.update(t, o)
+        nt, no = compatibility.update(t, o)
+        no["rotations"]["pids"] = no["rotations"]["targetpids"]
+        return nt, no
 
     def test_new_error(self, tmp_path):
         nt, no = self._default_cards()
@@ -211,6 +213,17 @@ class TestEKO:
         no["rotations"]["targetgrid"] = txg
         no["rotations"]["inputgrid"] = ixg
         eko = struct.EKO.new(nt, no)
+        # Targetgrid and inputgrid should not be anymore in the opcard
+        # They are not used anymore
+        assert eko.interpolator(False, True).xgrid == interpolation.XGrid(
+            no["rotations"]["xgrid"]
+        )
+        assert eko.interpolator(False, False).xgrid == interpolation.XGrid(
+            no["rotations"]["xgrid"]
+        )
+        # However you can esplicitly set them
+        eko.rotations._targetgrid = interpolation.XGrid(txg)
+        eko.rotations._inputgrid = interpolation.XGrid(ixg)
         assert eko.interpolator(False, True).xgrid == interpolation.XGrid(txg)
         assert eko.interpolator(False, False).xgrid == interpolation.XGrid(ixg)
 

--- a/tests/eko/test_runner.py
+++ b/tests/eko/test_runner.py
@@ -86,8 +86,9 @@ def test_targetgrid():
         tc,
         oc,
     )
+    # targetgrid and inputgrid in the opcard are now ignored, we are testing this
     # check actual value
-    np.testing.assert_allclose(o.rotations.targetgrid.raw, tgrid)
+    np.testing.assert_allclose(o.rotations.targetgrid.raw, actual_grid)
 
 
 def test_rotate_pids():
@@ -100,8 +101,9 @@ def test_rotate_pids():
     o = r.get_output()
     check_shapes(o, o.xgrid, o.xgrid, tc, oc)
     # check actual values
-    assert (o.rotations.targetpids == oc["rotations"]["targetpids"]).all()
-    assert (o.rotations.inputpids == oc["rotations"]["inputpids"]).all()
+    # targetpids and inputpids in the opcard are now ignored, we are testing this
+    assert (o.rotations.targetpids == oc["rotations"]["pids"]).all()
+    assert (o.rotations.inputpids == oc["rotations"]["pids"]).all()
 
 
 def check_shapes(o, txs, ixs, theory_card, operators_card):
@@ -113,13 +115,12 @@ def check_shapes(o, txs, ixs, theory_card, operators_card):
     op_inputgrid = operators_card["rotations"]["inputgrid"]
     # check output = input
     np.testing.assert_allclose(o.xgrid.raw, operators_card["rotations"]["xgrid"])
+    # targetgrid and inputgrid in the opcard are now ignored, we are testing this
     np.testing.assert_allclose(
         o.rotations.targetgrid.raw,
-        op_targetgrid if op_targetgrid is not None else txs.raw,
+        txs.raw,
     )
-    np.testing.assert_allclose(
-        o.rotations.inputgrid.raw, op_inputgrid if op_inputgrid is not None else ixs.raw
-    )
+    np.testing.assert_allclose(o.rotations.inputgrid.raw, ixs.raw)
     for k in ["interpolation_polynomial_degree", "interpolation_is_log"]:
         assert getattr(o.configs, k) == operators_card["configs"][k]
     np.testing.assert_allclose(o.Q02, theory_card["Q0"] ** 2)

--- a/tests/ekobox/test_evol_pdf.py
+++ b/tests/ekobox/test_evol_pdf.py
@@ -37,21 +37,23 @@ def test_evolve_pdfs_run(fake_lhapdf, cd):
 
 def test_evolve_pdfs_dump_path(fake_lhapdf, cd):
     n = "test_evolve_pdfs_dump_path"
-    peko = fake_lhapdf / ev_p.ekofileid(theory, op)
-    out.dump_tar(eko.run_dglap(theory, op), peko)
+    nt, no = compatibility.update(theory, op)
+    peko = fake_lhapdf / ev_p.ekofileid(nt, no)
+    out.dump_tar(eko.run_dglap(nt, no), peko)
     assert peko.exists()
     with cd(fake_lhapdf):
-        ev_p.evolve_pdfs([toy.mkPDF("", 0)], theory, op, name=n, path=fake_lhapdf)
+        ev_p.evolve_pdfs([toy.mkPDF("", 0)], nt, no, name=n, path=fake_lhapdf)
     p = fake_lhapdf / n
     assert p.exists()
 
 
 def test_evolve_pdfs_dump_file(fake_lhapdf, cd):
     n = "test_evolve_pdfs_dump_file"
-    peko = fake_lhapdf / ev_p.ekofileid(theory, op)
-    out.dump_tar(eko.run_dglap(theory, op), peko)
+    nt, no = compatibility.update(theory, op)
+    peko = fake_lhapdf / ev_p.ekofileid(nt, no)
+    out.dump_tar(eko.run_dglap(nt, no), peko)
     assert peko.exists()
     with cd(fake_lhapdf):
-        ev_p.evolve_pdfs([toy.mkPDF("", 0)], theory, op, name=n, path=peko)
+        ev_p.evolve_pdfs([toy.mkPDF("", 0)], nt, no, name=n, path=peko)
     p = fake_lhapdf / n
     assert p.exists()

--- a/tests/ekobox/test_evol_pdf.py
+++ b/tests/ekobox/test_evol_pdf.py
@@ -2,6 +2,7 @@ from banana import toy
 
 import eko
 import eko.output.legacy as out
+from eko import compatibility
 from ekobox import evol_pdf as ev_p
 from ekobox import operators_card as oc
 from ekobox import theory_card as tc
@@ -21,9 +22,10 @@ def test_evolve_pdfs_run(fake_lhapdf, cd):
     mytmp = fake_lhapdf / "install"
     mytmp.mkdir()
     store_path = mytmp / "test.tar"
+    nt, no = compatibility.update(theory, op)
     with cd(mytmp):
         ev_p.evolve_pdfs(
-            [toy.mkPDF("", 0)], theory, op, install=True, name=n, store_path=store_path
+            [toy.mkPDF("", 0)], nt, no, install=True, name=n, store_path=store_path
         )
     p = fake_lhapdf / n
     assert p.exists()

--- a/tests/ekobox/test_info_file.py
+++ b/tests/ekobox/test_info_file.py
@@ -2,6 +2,7 @@ import math
 
 import numpy as np
 
+from eko import compatibility
 from ekobox import info_file
 from ekobox import operators_card as oc
 from ekobox import theory_card as tc
@@ -10,14 +11,15 @@ from ekobox import theory_card as tc
 def test_build():
     op = oc.generate([10, 100])
     theory = tc.generate(1, 10.0, update={"alphas": 0.2})
+    nt, no = compatibility.update(theory, op)
     info = info_file.build(
-        theory, op, 4, info_update={"SetDesc": "Prova", "NewArg": 15.3, "MTop": 1.0}
+        nt, no, 4, info_update={"SetDesc": "Prova", "NewArg": 15.3, "MTop": 1.0}
     )
     assert info["AlphaS_MZ"] == 0.2
     assert info["SetDesc"] == "Prova"
     assert info["NewArg"] == 15.3
     assert info["NumMembers"] == 4
-    assert info["MTop"] == theory["mt"]
-    np.testing.assert_allclose(info["QMin"], math.sqrt(op["Q2grid"][0]), rtol=1e-5)
-    assert info["XMin"] == op["interpolation_xgrid"][0]
-    assert info["XMax"] == op["interpolation_xgrid"][-1] == 1.0
+    assert info["MTop"] == nt["mt"]
+    np.testing.assert_allclose(info["QMin"], math.sqrt(no["Q2grid"][0]), rtol=1e-5)
+    assert info["XMin"] == no["rotations"]["xgrid"][0]
+    assert info["XMax"] == no["rotations"]["xgrid"][-1] == 1.0

--- a/tests/ekomark/test_apply.py
+++ b/tests/ekomark/test_apply.py
@@ -11,7 +11,7 @@ class TestApply:
         pdf_grid = apply.apply_pdf(o, fake_pdf)
         assert len(pdf_grid) == len(fake_card["Q2grid"])
         pdfs = pdf_grid[q2_out]["pdfs"]
-        assert list(pdfs.keys()) == o.rotations.targetpids
+        assert list(pdfs.keys()) == list(o.rotations.targetpids)
         ref_pid1 = fake_card["Q2grid"][q2_out]["operator"][0, :, 1, :] @ np.ones(
             len(o.rotations.xgrid)
         )
@@ -25,7 +25,7 @@ class TestApply:
         pdf_grid = apply.apply_pdf(o, fake_pdf, target_grid)
         assert len(pdf_grid) == 1
         pdfs = pdf_grid[q2_out]["pdfs"]
-        assert list(pdfs.keys()) == o.rotations.targetpids
+        assert list(pdfs.keys()) == list(o.rotations.targetpids)
 
     def test_apply_flavor(self, fake_legacy, fake_pdf, monkeypatch):
         o, fake_card = fake_legacy


### PR DESCRIPTION
We want to have a file called `metadata.yaml` in which we can store the relevant metadata for the operators as the `targetgrid`, the `inputgrid`, the `targetpids` and the `inputpids`. 

Moreover we want to move the `operator_card` and the `theory_card` inside a folder `log` in which we will also store all the logs of the functions acting on the operator, in order to ensure reproducibility. @felixhekhorn @AleCandido 