### PR TITLE
Add ekore in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ packages = [
   { include = "eko", from = "src" },
   { include = "ekomark", from = "src" },
   { include = "ekobox", from = "src" },
+  { include = "ekore", from = "src" },
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
as said was simply missing and thus rtd was failing