### PR TITLE
Fix LHA VFNS SV benchmark

### DIFF
--- a/benchmarks/lha_paper_bench.py
+++ b/benchmarks/lha_paper_bench.py
@@ -246,8 +246,9 @@ class BenchmarkFFNS_polarized(BenchmarkFFNS):
 
 if __name__ == "__main__":
     # Benchmark to LHA
-    obj = BenchmarkFFNS_polarized()
+    # obj = BenchmarkFFNS_polarized()
     # obj = BenchmarkFFNS()
+    obj = BenchmarkVFNS()
     # obj.benchmark_plain(1)
     obj.benchmark_sv(1)
 

--- a/src/eko/runner/legacy.py
+++ b/src/eko/runner/legacy.py
@@ -92,7 +92,7 @@ class Runner:
             couplings=new_theory.couplings,
             order=new_theory.order,
             method=couplings_mod_ev(new_operator.configs.evolution_method),
-            masses=masses,
+            masses=np.array(masses) / new_theory.xif**2,
             hqm_scheme=new_theory.quark_masses_scheme,
             thresholds_ratios=thresholds_ratios,
         )


### PR DESCRIPTION
Closes #215 

The fix here mirrors the original behaviour in https://github.com/NNPDF/eko/blob/d32b95a8df938cb96efe5237a1b778832849a539/src/eko/couplings.py#L445-L453

I wonder whether we need to guard this division by scheme A ...