### PR TITLE
Polarized ToyLH from genpdf

### DIFF
--- a/src/ekobox/genpdf/__init__.py
+++ b/src/ekobox/genpdf/__init__.py
@@ -60,6 +60,13 @@ def take_data(parent_pdf_set=None, members=False, xgrid=None, Q2grid=None):
             all_blocks.append(
                 [generate_block(toylh.xfxQ2, xgrid, Q2grid, br.flavor_basis_pids)]
             )
+        elif parent_pdf_set in ["toylh_polarized", "toy_pol"]:
+            info = copy.deepcopy(load.Toy_info)
+            toylh = toy.mkPDF("ToyLH_polarized", 0)
+            all_blocks.append(
+                [generate_block(toylh.xfxQ2, xgrid, Q2grid, br.flavor_basis_pids)]
+            )
+
         else:
             info = load.load_info_from_file(parent_pdf_set)
             # iterate on members
@@ -104,6 +111,8 @@ def generate_pdf(
     If `parent_pdf_set` is the name of an available PDF set,
     it will be used as parent. In order to use the toy PDF
     as parent, it is enough to set `parent_pdf_set` to "toy" or "toylh".
+    In order to use the toy Polarized PDF
+    as parent, it is enough to set `parent_pdf_set` to "toylh_polarized" or "toy_pol".
     If `parent_pdf_set` is not specified, a debug PDF constructed as
     x * (1-x) for every flavor will be used as parent.
     It is also possible to provide custom functions for each flavor
@@ -114,7 +123,7 @@ def generate_pdf(
     on custom combinations of PIDs, it is also possible to pass a list
     containing the desired factors for each flavor.
 
-    The default behaviour is to generate only one member for a PDF set
+    The default behavior is to generate only one member for a PDF set
     (the zero member) but it can be changed setting to True the `members` flag.
 
     The `info_update` argument is a dictionary and provide to the user as a way


### PR DESCRIPTION
This PR is to allow generation of a Polarised ToyLH pdf as `lhapdf.PDF` object.

@Radonirinaunimi to generate it you can do: 

```
genpdf generate ToyLH_pol 21 1 2 3 4 -p toy_pol -i
```