### PR TITLE
Add -1 to QCD order in info file

### DIFF
--- a/src/ekobox/info_file.py
+++ b/src/ekobox/info_file.py
@@ -45,7 +45,7 @@ def build(
     template_info["XMin"] = float(operators_card.rotations.xgrid.raw[0])
     template_info["XMax"] = float(operators_card.rotations.xgrid.raw[-1])
     template_info["NumMembers"] = num_members
-    template_info["OrderQCD"] = theory_card.order[0]
+    template_info["OrderQCD"] = theory_card.order[0] - 1
     template_info["QMin"] = round(math.sqrt(operators_card.mu2grid[0]), 4)
     template_info["QMax"] = round(math.sqrt(operators_card.mu2grid[-1]), 4)
     template_info["MZ"] = theory_card.couplings.alphas.scale
@@ -56,7 +56,7 @@ def build(
     template_info["MBottom"] = theory_card.quark_masses.b.value
     template_info["MTop"] = theory_card.quark_masses.t.value
     template_info["AlphaS_MZ"] = theory_card.couplings.alphas.value
-    template_info["AlphaS_OrderQCD"] = theory_card.order[0]
+    template_info["AlphaS_OrderQCD"] = theory_card.order[0] - 1
     evmod = couplings.couplings_mod_ev(operators_card.configs.evolution_method)
     quark_masses = [(x.value) ** 2 for x in theory_card.quark_masses]
     sc = couplings.Couplings(


### PR DESCRIPTION
It seems that after the QED PR was merged (cc @niclaurenti ) we forgot to add the -1 here. If you know other places in which we may have forgotten, please comment here and I will fix. @felixhekhorn @AleCandido 

@giacomomagni I tag you because this is related to the issue you opened for `evolven3fit_new`.