### PR TITLE
Fix IO for LHA bot

### DIFF
--- a/benchmarks/lha_paper_bench.py
+++ b/benchmarks/lha_paper_bench.py
@@ -252,7 +252,7 @@ class FFNS_polarized(FFNS):
             theory_updates,
             [
                 {
-                    "Q2grid": [1e4],
+                    "mugrid": [1e2],
                     "ev_op_iterations": 10,
                     "interpolation_xgrid": lambertgrid(60).tolist(),
                     "polarized": True,

--- a/doc/source/code/IO.rst
+++ b/doc/source/code/IO.rst
@@ -126,9 +126,9 @@ The benchmark settings are available at :mod:`ekomark.data.operators`.
   * - ``interpolation_xgrid``
     - :py:obj:`list(float)`
     - x-grid at which the |EKO| is computed.
-  * - ``Q2grid``
+  * - ``mugrid``
     - :py:obj:`list(float)`
-    - Q2-grid at which the |EKO| is computed (in GeV^2).
+    - target grid at which the |EKO| is computed (in GeV).
   * - ``interpolation_is_log``
     - :py:obj:`bool`
     - If ``True`` use logarithmic interpolation.

--- a/src/eko/io/runcards.py
+++ b/src/eko/io/runcards.py
@@ -313,7 +313,7 @@ class Legacy:
         elif old["HQ"] == "MSBAR":
             new["heavy"]["masses"] = [[m, mu] for m, mu in zip(ms, mus)]
         else:
-            raise ValueError(f"Unkown quark mass sceme '{old['HQ']}'")
+            raise ValueError(f"Unknown mass scheme '{old['HQ']}'")
 
         new["xif"] = old["XIF"]
 

--- a/src/ekomark/benchmark/external/LHA_utils.py
+++ b/src/ekomark/benchmark/external/LHA_utils.py
@@ -126,7 +126,7 @@ def compute_LHA_data(theory, operators, rotate_to_evolution_basis=False):
 
     """
     polarized = operators["polarized"]
-    mu2grid = operators["mu2grid"]
+    mu2grid = np.power(operators["mugrid"], 2.0)
     if not np.allclose(mu2grid, [1e4]):
         raise ValueError("mu2grid has to be [1e4]")
     order = theory["PTO"]

--- a/src/ekomark/navigator/navigator.py
+++ b/src/ekomark/navigator/navigator.py
@@ -76,7 +76,7 @@ class NavigatorApp(bnav.navigator.NavigatorApp):
             + f"{'log' if op['interpolation_is_log'] else 'x'}"
             + f"^{op['interpolation_polynomial_degree']}"
         )
-        obj["Q2grid"] = op["Q2grid"]
+        obj["mugrid"] = op["mugrid"]
         obj["max_ord"] = op["ev_op_max_order"]
         obj["iters"] = op["ev_op_iterations"]
         obj["skip_ns"] = op["debug_skip_non_singlet"]

--- a/tests/eko/io/test_runcards.py
+++ b/tests/eko/io/test_runcards.py
@@ -1,10 +1,15 @@
+import copy
 from dataclasses import fields
+from io import StringIO
 
 import numpy as np
 import pytest
+import yaml
+from banana.data.theories import default_card as theory_card
 
 from eko import interpolation
 from eko.io import runcards as rc
+from ekomark.data.operators import default_card as operator_card
 
 
 class TestRotations:
@@ -50,3 +55,27 @@ def test_flavored_mu2grid():
 
     flavored = rc.flavored_mugrid(mugrid, masses, ratios)
     assert pytest.approx([flav for _, flav in flavored]) == [3, 3, 4, 4, 5, 5, 6, 6]
+
+    # check we can dump
+    stream = StringIO()
+    ser = yaml.safe_dump(flavored, stream)
+    stream.seek(0)
+    deser = yaml.safe_load(stream)
+    assert len(flavored) == len(deser)
+    # after deserialization on is now list instead of tuple
+    for t, l in zip(flavored, deser):
+        assert len(t) == len(l)
+        assert t == tuple(l)
+
+
+def test_runcards_ekomark():
+    # check conversion
+    tc = copy.deepcopy(theory_card)
+    oc = copy.deepcopy(operator_card)
+    nt, no = rc.update(tc, oc)
+    assert isinstance(nt, rc.TheoryCard)
+    assert isinstance(no, rc.OperatorCard)
+    # check is idempotent
+    nnt, nno = rc.update(nt, no)
+    assert nnt == nt
+    assert nno == no


### PR DESCRIPTION
Closes #237 

This PR fixes
- #237 and adds the relevant test
- a inconsistent translation of `mu2grid` -> `mugrid` in LHA
- the output of `flavored_mugrid` to be serializable and adds the relevant test
- left-over `Q2grid` in LHA benchmark
- left-over `Q2grid` in navigator
- left-over `Q2grid` in docs

further comments:
- #237 also affects [yadism](https://github.com/NNPDF/yadism/blob/9617329a4025a27ac6de99c0ba904e276fcb8dfb/src/yadism/output.py#L99) of course
- the current implementation looses track of `QrefQED` since there is no such thing any longer - what should we do? should we translate the existence to `couplings.em_running`? should we change the theory again? (meaning `banana`)
- by creating this PR we can test the trigger for #227 