### PR TITLE
Fix non-singlet QED bug

### DIFF
--- a/src/eko/evolution_operator/__init__.py
+++ b/src/eko/evolution_operator/__init__.py
@@ -770,9 +770,9 @@ class Operator(sv.ModeMixin):
                 labels.append(br.non_singlet_unified_labels[0])
                 labels.append(br.non_singlet_unified_labels[2])
                 # -u and -d become different starting from O(as1aem1) or O(aem2)
-                if self.order[1] >= 2 or self.order[0] >= 1:
-                    labels.append(br.non_singlet_unified_labels[1])
-                    labels.append(br.non_singlet_unified_labels[3])
+                # but at this point order is at least (1, 1)
+                labels.append(br.non_singlet_unified_labels[1])
+                labels.append(br.non_singlet_unified_labels[3])
                 labels.extend(br.valence_unified_labels)
             if self.config["debug_skip_singlet"]:
                 logger.warning("%s: skipping singlet sector", self.log_label)

--- a/src/eko/kernels/non_singlet_qed.py
+++ b/src/eko/kernels/non_singlet_qed.py
@@ -130,8 +130,8 @@ def dispatcher(
     alphaem_running,
     nf,
     ev_op_iterations,
-    mu2_to,
     mu2_from,
+    mu2_to,
 ):
     r"""Determine used kernel and call it.
 
@@ -174,13 +174,13 @@ def dispatcher(
         aem_half,
         nf,
         ev_op_iterations,
-        mu2_to,
         mu2_from,
+        mu2_to,
     )
 
 
 @nb.njit(cache=True)
-def fixed_alphaem_exact(order, gamma_ns, a1, a0, aem, nf, mu2_to, mu2_from):
+def fixed_alphaem_exact(order, gamma_ns, a1, a0, aem, nf, mu2_from, mu2_to):
     """Compute exact solution for fixed alphaem.
 
     Parameters
@@ -222,7 +222,7 @@ def fixed_alphaem_exact(order, gamma_ns, a1, a0, aem, nf, mu2_to, mu2_from):
 
 
 @nb.njit(cache=True)
-def exact(order, gamma_ns, as_list, aem_half, nf, ev_op_iterations, mu2_to, mu2_from):
+def exact(order, gamma_ns, as_list, aem_half, nf, ev_op_iterations, mu2_from, mu2_to):
     """Compute exact solution for running alphaem.
 
     Parameters
@@ -259,5 +259,5 @@ def exact(order, gamma_ns, as_list, aem_half, nf, ev_op_iterations, mu2_to, mu2_
         a0 = as_list[step - 1]
         mu2_from = mu2_steps[step - 1]
         mu2_to = mu2_steps[step]
-        res *= fixed_alphaem_exact(order, gamma_ns, a1, a0, aem, nf, mu2_to, mu2_from)
+        res *= fixed_alphaem_exact(order, gamma_ns, a1, a0, aem, nf, mu2_from, mu2_to)
     return res


### PR DESCRIPTION
This PR fixes a bug in the non-singlet sector of the QED evolution that I introduced when I refactored that part.
This should explain the bug that we where seeing in the charm evolution in

https://vp.nnpdf.science/S68HlNnPRJCHjJLCd5KYkQ==/Scales1_pdf_report_report.html#Scales1_pdf_report_PDFnormalize0_Basespecs0_PDFscalespecs1_plot_pdfs_c

