### PR TITLE
Write the right `nf` in the LHAPDF `.info` file.

### DIFF
--- a/src/ekobox/info_file.py
+++ b/src/ekobox/info_file.py
@@ -39,7 +39,7 @@ def build(
     template_info["Authors"] = ""
     template_info["FlavorScheme"] = "variable"
     template_info.update(info_update)
-    template_info["NumFlavors"] = theory_card.heavy.num_flavs_max_pdf
+    template_info["NumFlavors"] = max(nf for _, nf in op.mugrid)
     template_info["Flavors"] = [-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 21, 22]
     # TODO actually point to input grid
     template_info["XMin"] = float(operators_card.xgrid.raw[0])

--- a/src/ekobox/info_file.py
+++ b/src/ekobox/info_file.py
@@ -39,7 +39,7 @@ def build(
     template_info["Authors"] = ""
     template_info["FlavorScheme"] = "variable"
     template_info.update(info_update)
-    template_info["NumFlavors"] = theory_card.couplings.max_num_flavs
+    template_info["NumFlavors"] = theory_card.heavy.num_flavs_max_pdf
     template_info["Flavors"] = [-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 21, 22]
     # TODO actually point to input grid
     template_info["XMin"] = float(operators_card.xgrid.raw[0])

--- a/src/ekobox/info_file.py
+++ b/src/ekobox/info_file.py
@@ -39,7 +39,7 @@ def build(
     template_info["Authors"] = ""
     template_info["FlavorScheme"] = "variable"
     template_info.update(info_update)
-    template_info["NumFlavors"] = theory.couplings.max_num_flavs
+    template_info["NumFlavors"] = theory_card.couplings.max_num_flavs
     template_info["Flavors"] = [-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 21, 22]
     # TODO actually point to input grid
     template_info["XMin"] = float(operators_card.xgrid.raw[0])

--- a/src/ekobox/info_file.py
+++ b/src/ekobox/info_file.py
@@ -39,7 +39,7 @@ def build(
     template_info["Authors"] = ""
     template_info["FlavorScheme"] = "variable"
     template_info.update(info_update)
-    template_info["NumFlavors"] = 14
+    template_info["NumFlavors"] = theory.couplings.max_num_flavs
     template_info["Flavors"] = [-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 21, 22]
     # TODO actually point to input grid
     template_info["XMin"] = float(operators_card.xgrid.raw[0])

--- a/src/ekobox/info_file.py
+++ b/src/ekobox/info_file.py
@@ -39,7 +39,7 @@ def build(
     template_info["Authors"] = ""
     template_info["FlavorScheme"] = "variable"
     template_info.update(info_update)
-    template_info["NumFlavors"] = max(nf for _, nf in op.mugrid)
+    template_info["NumFlavors"] = max(nf for _, nf in operators_card.mugrid)
     template_info["Flavors"] = [-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 21, 22]
     # TODO actually point to input grid
     template_info["XMin"] = float(operators_card.xgrid.raw[0])


### PR DESCRIPTION
Currently the `NumFlavors` written by eko in the `info` file correspond to the number of possible partons, while this field is actually the maximum `nf` used for the evolution of `alpha_s`.

Ref: https://lhapdf.hepforge.org/config.html