### PR TITLE
Enforce default for matching order at post-init time

### DIFF
--- a/src/eko/io/runcards.py
+++ b/src/eko/io/runcards.py
@@ -54,7 +54,7 @@ class TheoryCard(DictLike):
     def __post_init__(self):
         """Enforce defaults."""
         if self.matching_order is None:
-            self.matching_order = self.order
+            self.matching_order = (self.order[0] - 1, 0)
 
 
 @dataclass

--- a/src/eko/io/runcards.py
+++ b/src/eko/io/runcards.py
@@ -46,8 +46,7 @@ class TheoryCard(DictLike):
     xif: float
     """Ratio between factorization scale and process scale."""
     n3lo_ad_variation: N3LOAdVariation
-    """|N3LO| anomalous dimension variation: ``(gg_var, gq_var, qg_var,
-    qq_var)``."""
+    """|N3LO| anomalous dimension variation: ``(gg, gq, qg,qq)``."""
     matching_order: Optional[Order] = None
     """Matching conditions perturbative order tuple, ``(QCD, QED)``."""
 

--- a/src/eko/io/runcards.py
+++ b/src/eko/io/runcards.py
@@ -1,9 +1,7 @@
 """Structures to hold runcards information.
 
-All energy scales in the runcards should be saved linearly, not the squared
-value, for consistency.
-Squares are consistenly taken inside.
-
+All energy scales in the runcards should be saved linearly, not the
+squared value, for consistency. Squares are consistenly taken inside.
 """
 from dataclasses import dataclass
 from math import nan
@@ -48,9 +46,15 @@ class TheoryCard(DictLike):
     xif: float
     """Ratio between factorization scale and process scale."""
     n3lo_ad_variation: N3LOAdVariation
-    """|N3LO| anomalous dimension variation: ``(gg_var, gq_var, qg_var, qq_var)``."""
+    """|N3LO| anomalous dimension variation: ``(gg_var, gq_var, qg_var,
+    qq_var)``."""
     matching_order: Optional[Order] = None
     """Matching conditions perturbative order tuple, ``(QCD, QED)``."""
+
+    def __post_init__(self):
+        """Enforce defaults."""
+        if self.matching_order is None:
+            self.matching_order = self.order
 
 
 @dataclass
@@ -71,6 +75,7 @@ class Configs(DictLike):
     """Evolution mode."""
     ev_op_max_order: Order
     """Maximum order to use in U matrices expansion.
+
     Used only in ``perturbative`` solutions.
     """
     ev_op_iterations: int
@@ -83,6 +88,7 @@ class Configs(DictLike):
     """Degree of elements of the intepolation polynomial basis."""
     interpolation_is_log: bool
     r"""Whether to use polynomials in :math:`\log(x)`.
+
     If `false`, polynomials are in :math:`x`.
     """
     polarized: bool
@@ -105,7 +111,8 @@ class OperatorCard(DictLike):
 
     # collections
     configs: Configs
-    """Specific configuration to be used during the calculation of these operators."""
+    """Specific configuration to be used during the calculation of these
+    operators."""
     debug: Debug
     """Debug configurations."""
 
@@ -276,7 +283,6 @@ def update(theory: Union[RawCard, TheoryCard], operator: Union[RawCard, Operator
 
         cards = update(theory, operator)
         assert update(*cards) == cards
-
     """
     if isinstance(theory, TheoryCard) or isinstance(operator, OperatorCard):
         # if one is not a dict, both have to be new cards
@@ -291,13 +297,12 @@ def update(theory: Union[RawCard, TheoryCard], operator: Union[RawCard, Operator
 def default_atlas(masses: list, matching_ratios: list):
     r"""Create default landscape.
 
-    This method should not be used to write new runcards, but rather to have a
-    consistent default for comparison with other softwares and existing PDF
-    sets.
-    There is no one-to-one relation between number of running flavors and final
-    scales, unless matchings are all applied. But this is a custom choice,
-    since it is possible to have PDFs in different |FNS| at the same scales.
-
+    This method should not be used to write new runcards, but rather to
+    have a consistent default for comparison with other softwares and
+    existing PDF sets. There is no one-to-one relation between number of
+    running flavors and final scales, unless matchings are all applied.
+    But this is a custom choice, since it is possible to have PDFs in
+    different |FNS| at the same scales.
     """
     matchings = (np.array(masses) * np.array(matching_ratios)) ** 2
     return Atlas(matchings.tolist(), (0.0, 0))
@@ -306,16 +311,15 @@ def default_atlas(masses: list, matching_ratios: list):
 def flavored_mugrid(mugrid: list, masses: list, matching_ratios: list):
     r"""Upgrade :math:`\mu^2` grid to contain also target number flavors.
 
-    It determines the number of flavors for the PDF set at the target scale,
-    inferring it according to the specified scales.
+    It determines the number of flavors for the PDF set at the target
+    scale, inferring it according to the specified scales.
 
-    This method should not be used to write new runcards, but rather to have a
-    consistent default for comparison with other softwares and existing PDF
-    sets.
-    There is no one-to-one relation between number of running flavors and final
-    scales, unless matchings are all applied. But this is a custom choice,
-    since it is possible to have PDFs in different |FNS| at the same scales.
-
+    This method should not be used to write new runcards, but rather to
+    have a consistent default for comparison with other softwares and
+    existing PDF sets. There is no one-to-one relation between number of
+    running flavors and final scales, unless matchings are all applied.
+    But this is a custom choice, since it is possible to have PDFs in
+    different |FNS| at the same scales.
     """
     atlas = default_atlas(masses, matching_ratios)
     return [(mu, nf_default(mu**2, atlas)) for mu in mugrid]

--- a/src/eko/runner/parts.py
+++ b/src/eko/runner/parts.py
@@ -8,7 +8,6 @@
     After #242, the goal is to update :class:`Operator` and
     :class:`OperatorMatrixElement` to simplify the computation and passing down
     parameters.
-
 """
 import numpy as np
 
@@ -28,7 +27,6 @@ def managers(eko: EKO) -> dict:
     .. todo::
 
         Legacy interface, avoid managers usage.
-
     """
     tcard = eko.theory_card
     ocard = eko.operator_card
@@ -60,7 +58,6 @@ def blowup_info(eko: EKO) -> dict:
     evolution history (to determine if evolution is backward in flavor,
     irrespectively of happening for an increasing or decreasing interval in
     scale at fixed flavor).
-
     """
     return dict(intrinsic_range=[4, 5, 6], qed=eko.theory_card.order[1] > 0)
 
@@ -71,7 +68,6 @@ def evolve_configs(eko: EKO) -> dict:
     .. todo::
 
         Legacy interface, make use of a dedicated object.
-
     """
     tcard = eko.theory_card
     ocard = eko.operator_card
@@ -89,9 +85,7 @@ def evolve_configs(eko: EKO) -> dict:
         ModSV=ocard.configs.scvar_method,
         n3lo_ad_variation=tcard.n3lo_ad_variation,
         # Here order is shifted by one, no QED matching is available so far.
-        matching_order=tcard.matching_order
-        if tcard.matching_order is not None
-        else (tcard.order[0] - 1, 0),
+        matching_order=tcard.matching_order,
     )
 
 
@@ -116,7 +110,6 @@ def matching_configs(eko: EKO) -> dict:
     .. todo::
 
         Legacy interface, make use of a dedicated object.
-
     """
     tcard = eko.theory_card
     ocard = eko.operator_card
@@ -138,7 +131,6 @@ def match(eko: EKO, recipe: Matching) -> Operator:
     All the operators are blown up to flavor basis, and they are saved and
     joined in that unique basis. So, the only rotation used is towards that
     basis, and encoded in the blowing up prescription.
-
     """
     kthr = eko.theory_card.heavy.squared_ratios[recipe.hq - 4]
     op = ome.OperatorMatrixElement(


### PR DESCRIPTION
Hot fix for matching order setting.

It should be properly tested, but if merging this is urgent we can postpone it.