### PR TITLE
fixing the condition from #263

### DIFF
--- a/src/ekore/anomalous_dimensions/unpolarized/time_like/as3.py
+++ b/src/ekore/anomalous_dimensions/unpolarized/time_like/as3.py
@@ -265,7 +265,7 @@ def gamma_nsv(N, nf, cache):
     S11 = S1 + N1I
     S12 = S11 + N2I
     B1 = -S1 * NI
-    if abs(N.imag) < 0.00001 and abs(N.real) < 0.00001:
+    if abs(N.imag) < 0.00001 and abs(N.real - 1) < 0.00001:
         B1M = -zeta2
     else:
         B1M = -S1M * NMI


### PR DESCRIPTION
It appears I had made a mistake when reimplementing this code from https://github.com/vbertone/MELA/blob/master/src/evolution/andim_nnlo_tl.f#L117-118. It is now fixed. 

The ref in Vogt's code has this eqn which matches our definition of Mellin transform: 
![image](https://github.com/NNPDF/eko/assets/99052355/c2193c20-52b9-4a8f-a7c7-ba9cd9def9d8)

so with this, I think everything is consistent.