### PR TITLE
Add a nicer parametrization of aggQ3

### DIFF
--- a/src/ekore/operator_matrix_elements/unpolarized/space_like/as3/agg.py
+++ b/src/ekore/operator_matrix_elements/unpolarized/space_like/as3/agg.py
@@ -5,15 +5,33 @@ import numba as nb
 import numpy as np
 
 from .....harmonics import cache as c
+from .....harmonics.log_functions import (
+    lm11,
+    lm11m1,
+    lm11m2,
+    lm12,
+    lm12m1,
+    lm12m2,
+    lm13,
+    lm13m1,
+    lm13m2,
+    lm14m1,
+    lm14m2,
+)
 
 
 @nb.njit(cache=True)
 def a_gg3(n, cache, nf):
-    r"""Compute the approximate part of :math:`a_{gg}^{(3)}(N)`.
+    r"""Compute :math:`a_{gg}^{(3)}(N)`.
 
-    This is the part of :math:`A_{gg}^{S,(3)}(N)` proportional to :math:`\mathcal{O}(\epsilon^0)`,
-    the expression is presented in  :cite:`Ablinger:2022wbb`.
-    It contains binomial factors which are approximated.
+    The expression is presented in  :cite:`Ablinger:2022wbb`.
+
+    The :math:`n_f^0` piece is parametrized from:
+    the known small-x (eq. 4.10) and large-x (eq. 4.11)
+    limits, the expansion of the local and singular parts
+    in eq. 4.6, 4.7 and the first 15 Mellin moments up to N=30.
+    The analytical expression contains binomial factors
+    which are not handy to use.
 
     When using the code, please cite the complete list of references
     available in :mod:`~ekore.operator_matrix_elements.unpolarized.space_like.as3`.
@@ -37,30 +55,47 @@ def a_gg3(n, cache, nf):
     S2 = c.get(c.S2, cache, n)
     S3 = c.get(c.S3, cache, n)
     S4 = c.get(c.S4, cache, n)
-    S5 = c.get(c.S5, cache, n)
+
+    Lm11 = lm11(n, S1)
+    Lm12 = lm12(n, S1, S2)
+    Lm13 = lm13(n, S1, S2, S3)
+    Lm11m1 = lm11m1(n, S1)
+    Lm12m1 = lm12m1(n, S1, S2)
+    Lm13m1 = lm13m1(n, S1, S2, S3)
+    Lm14m1 = lm14m1(n, S1, S2, S3, S4)
+    Lm11m2 = lm11m2(n, S1)
+    Lm12m2 = lm12m2(n, S1, S2)
+    Lm13m2 = lm13m2(n, S1, S2, S3)
+    Lm14m2 = lm14m2(n, S1, S2, S3, S4)
     # the nf^0 part is parametrized since it contains nasty binomial factors.
     agg3_nf0_param = (
-        119.55586399490849
-        + 643.5919221725146 / (-1.0 + n) ** 2
-        - 4243.672748386901 / (-1.0 + n)
-        - 1097.3959566791473 / n**6
-        - 2166.223781401583 / n**5
-        + 5864.212793800409 / n**4
-        + 31055.955132702067 / n**3
-        + 5195.523226994994 / n**2
-        + 4052.670326185617 / n
-        + 723.5270116330819 * S1
-        - (24416.76276706736 * S1) / n**4
-        - (12798.647797499609 * S1) / n**3
-        - (1191.9103600256221 * S1) / n**2
-        - (411.7226853758584 * S1) / n
-        - 1.0287077597852439 * S1**2
-        + 0.055958522352878494 * S1**3
-        - 0.0011488227245772988 * S1**4
-        + 68.79337566373333 * S2
-        + 100.07538288542415 * S3
-        + 110.06866836903241 * S4
-        + 115.46020088075208 * S5
+        619.2420126046355
+        + 701.1986854426286 / (-1.0 + n) ** 2
+        - 4954.442786280953 / (-1.0 + n)
+        + 305.77777777777777 / n**6
+        - 668.4444444444445 / n**5
+        + 2426.352476661977 / n**4
+        - 3148.735962235475 / n**3
+        + 9155.33153602228 / n**2
+        + 5069.820034891387 / n
+        - 6471.478696979203 / (1.0 + n) ** 2
+        - 8987.70366338934 / (n + n**2)
+        - 21902.776840085757 / (2.0 + 3.0 * n + n**2)
+        - 78877.91436146703 / (3.0 + 4.0 * n + n**2)
+        - 207627.85210030797 / (6.0 + 5.0 * n + n**2)
+        + 860105.1673083167 / (6.0 + 11.0 * n + 6.0 * n**2 + n**3)
+        + 714.9711186248866 * S1
+        + 576.0307099030653 * Lm11
+        - 14825.806057017968 * Lm11m1
+        + 368095.9894734118 * Lm11m2
+        + 40.908173376688424 * Lm12
+        - 6838.198890554838 * Lm12m1
+        + 474165.7099083288 * Lm12m2
+        + 5.333333333333333 * Lm13
+        - 4424.7425689765805 * Lm13m1
+        + 50838.65442166183 * Lm13m2
+        - 508.9445773396529 * Lm14m1
+        + 28154.716500168193 * Lm14m2
     )
     agg3_nf1 = 0.75 * (
         -(

--- a/src/ekore/operator_matrix_elements/unpolarized/space_like/as3/agg.py
+++ b/src/ekore/operator_matrix_elements/unpolarized/space_like/as3/agg.py
@@ -27,11 +27,14 @@ def a_gg3(n, cache, nf):
     The expression is presented in  :cite:`Ablinger:2022wbb`.
 
     The :math:`n_f^0` piece is parametrized from:
-    the known small-x (eq. 4.10) and large-x (eq. 4.11)
-    limits, the expansion of the local and singular parts
-    in eq. 4.6, 4.7 and the first 15 Mellin moments up to N=30.
+
+    - the small-x limit :eqref:`4.10`
+    - the large-x limit :eqref:`4.11`
+    - the expansion of the local and singular parts in :eqref:`4.6, 4.7`
+    - the first 15 Mellin moments up to :math:`N=30`
+
     The analytical expression contains binomial factors
-    which are not handy to use.
+    which are not practical to use.
 
     When using the code, please cite the complete list of references
     available in :mod:`~ekore.operator_matrix_elements.unpolarized.space_like.as3`.
@@ -40,7 +43,7 @@ def a_gg3(n, cache, nf):
     ----------
     n : complex
         Mellin moment
-    cache: numpy.ndarray
+    cache : numpy.ndarray
         Harmonic sum cache
     nf : int
         number of active flavor below the threshold

--- a/tests/ekore/operator_matrix_elements/unpolarized/space_like/test_as3.py
+++ b/tests/ekore/operator_matrix_elements/unpolarized/space_like/test_as3.py
@@ -196,7 +196,7 @@ def test_Blumlein_3():
             aS3 = A_singlet(N, sx_cache, nf, L)
 
             np.testing.assert_allclose(
-                aS3[0, 0], ref_val_gg[L][idx] + ref_val_a_gg[L][idx], rtol=3e-6
+                aS3[0, 0], ref_val_gg[L][idx] + ref_val_a_gg[L][idx], rtol=9e-6
             )
 
             np.testing.assert_allclose(aS3[0, 1], ref_val_gq[L][idx], rtol=2e-6)


### PR DESCRIPTION
in this PR I'd like to make the $a_{gg,Q}^{(3)}$ parametrization to have a easier and compact form in `x-space`, 
such that can be easily digest alo in that case. 

As visible in the two plots below, the new parametrization is equivalent to the previous one.
 
Relative difference in linear scale:
[aggQ3_rel_diff.pdf](https://github.com/NNPDF/eko/files/14555988/aggQ3_rel_diff.pdf)

Comparison in log scale:
[aggQ3_diff.pdf](https://github.com/NNPDF/eko/files/14555989/aggQ3_diff.pdf)

This parametrization can be shared easily with the MSHT people.
