### PR TITLE
Fix large-x wiggles 

### DIFF
--- a/src/eko/mellin.py
+++ b/src/eko/mellin.py
@@ -223,7 +223,7 @@ class Path:
     def __init__(self, t, logx, axis_offset):
         self.t = t
         # TODO: shall we use: 0.4 * 16.0 / ( - logx) ?
-        self.r = 0.4 * 16.0 / (1.0 - logx)
+        self.r = 0.4 * 16.0 / (0.1 - logx)
         if axis_offset:
             self.o = 1.0
         else:

--- a/src/eko/mellin.py
+++ b/src/eko/mellin.py
@@ -222,7 +222,10 @@ class Path:
 
     def __init__(self, t, logx, axis_offset):
         self.t = t
-        # TODO: shall we use: 0.4 * 16.0 / ( - logx) ?
+        # The prescription suggested by :cite:`Abate` for r is 0.4 * M / ( - logx)
+        # with M the number of accurate digits; Maria Ubiali suggested in her thesis M = 16.
+        # However, this seems to yield unstable results for the OME in the large x region
+        # so we add an additional regularization, which makes the path less "edgy" there
         self.r = 0.4 * 16.0 / (0.1 - logx)
         if axis_offset:
             self.o = 1.0

--- a/src/ekobox/evol_pdf.py
+++ b/src/ekobox/evol_pdf.py
@@ -8,7 +8,6 @@ import numpy as np
 import eko
 from eko import basis_rotation as br
 from eko.io import EKO
-from eko.runner import managed
 
 from . import apply, genpdf, info_file
 
@@ -57,7 +56,7 @@ def evolve_pdfs(
     else:
         if store_path is None:
             raise ValueError("'store_path' required if 'path' is not provided.")
-        managed.solve(theory_card, operators_card, path=store_path)
+        eko.solve(theory_card, operators_card, path=store_path)
         eko_path = store_path
 
     # apply PDF to eko

--- a/src/ekobox/evol_pdf.py
+++ b/src/ekobox/evol_pdf.py
@@ -8,6 +8,7 @@ import numpy as np
 import eko
 from eko import basis_rotation as br
 from eko.io import EKO
+from eko.runner import managed
 
 from . import apply, genpdf, info_file
 
@@ -56,7 +57,7 @@ def evolve_pdfs(
     else:
         if store_path is None:
             raise ValueError("'store_path' required if 'path' is not provided.")
-        eko.solve(theory_card, operators_card, path=store_path)
+        managed.solve(theory_card, operators_card, path=store_path)
         eko_path = store_path
 
     # apply PDF to eko

--- a/tests/eko/evolution_operator/test_init.py
+++ b/tests/eko/evolution_operator/test_init.py
@@ -27,7 +27,7 @@ def test_quad_ker_errors():
                 mode1=0,
                 method="",
                 is_log=True,
-                logx=0.1,
+                logx=np.log(0.1),
                 areas=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
                 as_list=[2.0, 1.0],
                 mu2_from=1.0,


### PR DESCRIPTION
Here we change the `r` parameter regulating the Talboth path, to make the large-x integration smoother. 
@scarlehoff 