### PR TITLE
Use nf to generate alpha_s

### DIFF
--- a/src/ekobox/evol_pdf.py
+++ b/src/ekobox/evol_pdf.py
@@ -1,13 +1,13 @@
 """Tools to evolve actual PDFs."""
 
 import pathlib
-from collections import defaultdict
 
 from eko import basis_rotation as br
 from eko.io import EKO
 from eko.runner import managed
 
 from . import apply, genpdf, info_file
+from .utils import regroup_evolgrid
 
 DEFAULT_NAME = "eko.tar"
 
@@ -93,14 +93,6 @@ def evolve_pdfs(
 
     if install:
         genpdf.install_pdf(name)
-
-
-def regroup_evolgrid(evolgrid: list):
-    """Split evolution points by nf and sort by scale."""
-    by_nf = defaultdict(list)
-    for q, nf in sorted(evolgrid, key=lambda ep: ep[1]):
-        by_nf[nf].append(q)
-    return {nf: sorted(qs) for nf, qs in by_nf.items()}
 
 
 def collect_blocks(evolved_PDF: dict, q2block_per_nf: dict, xgrid: list):

--- a/src/ekobox/info_file.py
+++ b/src/ekobox/info_file.py
@@ -84,18 +84,8 @@ def build_alphas(
     template_info = {}
     template_info["AlphaS_MZ"] = theory_card.couplings.alphas
     template_info["AlphaS_OrderQCD"] = theory_card.order[0] - 1
-
-    # check we have disjoint scale ranges
+    # prepare
     evolgrid = regroup_evolgrid(operators_card.mugrid)
-    nfs = list(evolgrid.keys())
-    for j in range(len(nfs) - 1):
-        # equal points are allowed by LHAPDF
-        if evolgrid[nfs[j]][-1] > evolgrid[nfs[j + 1]][0]:
-            raise ValueError(
-                f"Last scale point for nf={nfs[j]} is bigger than first in nf={nfs[j+1]}"
-            )
-
-    # add actual values
     evmod = couplings.couplings_mod_ev(operators_card.configs.evolution_method)
     quark_masses = [(x.value) ** 2 for x in theory_card.heavy.masses]
     sc = couplings.Couplings(
@@ -106,6 +96,7 @@ def build_alphas(
         hqm_scheme=theory_card.heavy.masses_scheme,
         thresholds_ratios=np.power(list(iter(theory_card.heavy.matching_ratios)), 2.0),
     )
+    # add actual values
     alphas_values = []
     alphas_qs = []
     for nf, mus in evolgrid.items():

--- a/src/ekobox/info_file.py
+++ b/src/ekobox/info_file.py
@@ -68,19 +68,13 @@ def build(
         hqm_scheme=theory_card.heavy.masses_scheme,
         thresholds_ratios=np.power(list(iter(theory_card.heavy.matching_ratios)), 2.0),
     )
-    alphas_values = np.array(
-        [
-            4.0
-            * np.pi
-            * sc.a_s(
-                muf2,
-            )
-            for muf2 in operators_card.mu2grid
-        ],
-        dtype=float,
-    )
-    template_info["AlphaS_Vals"] = alphas_values.tolist()
-    template_info["AlphaS_Qs"] = np.array(
-        [mu for mu, _ in operators_card.mugrid]
-    ).tolist()
+
+    alphas_values = []
+    alphas_qs = []
+    for mu, nf in operators_card.mugrid:
+        alphas_values.append(float(4.0 * np.pi * sc.a_s(mu * mu, nf_to=nf)))
+        alphas_qs.append(mu)
+
+    template_info["AlphaS_Vals"] = alphas_values
+    template_info["AlphaS_Qs"] = alphas_qs
     return template_info

--- a/src/ekobox/utils.py
+++ b/src/ekobox/utils.py
@@ -1,6 +1,7 @@
 """Generic utilities to work with EKOs."""
 
 import os
+from collections import defaultdict
 from typing import Optional
 
 import numpy as np
@@ -78,3 +79,11 @@ def ekos_product(
 
     if path is not None:
         final_eko.close()
+
+
+def regroup_evolgrid(evolgrid: list):
+    """Split evolution points by nf and sort by scale."""
+    by_nf = defaultdict(list)
+    for q, nf in sorted(evolgrid, key=lambda ep: ep[1]):
+        by_nf[nf].append(q)
+    return {nf: sorted(qs) for nf, qs in by_nf.items()}

--- a/tests/ekobox/test_evol_pdf.py
+++ b/tests/ekobox/test_evol_pdf.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from banana import toy
 
 import eko
@@ -48,6 +49,21 @@ def test_evolve_pdfs_dump_path(fake_lhapdf, cd):
         ev_p.evolve_pdfs([toy.mkPDF("", 0)], theory, op, name=n, path=fake_lhapdf)
     p = fake_lhapdf / n
     assert p.exists()
+
+
+def test_evolve_pdfs_bad_scales(fake_lhapdf, cd):
+    """Bad scale configurations."""
+    theory, op = init_cards()
+    n = "test_evolve_pdfs_bad_scales"
+    op = cards.example.operator()
+    op.mugrid = [(5.0, 3), (15.0, 4), (10.0, 5), (100.0, 5)]
+    with pytest.raises(ValueError, match="is bigger"):
+        with cd(fake_lhapdf):
+            ev_p.evolve_pdfs([toy.mkPDF("", 0)], theory, op, name=n, path=fake_lhapdf)
+    op.mugrid = [(5.0, 3), (10.0, 3), (10.0, 4), (15.0, 4), (10.0, 5)]
+    with pytest.raises(ValueError, match="is bigger"):
+        with cd(fake_lhapdf):
+            ev_p.evolve_pdfs([toy.mkPDF("", 0)], theory, op, name=n, path=fake_lhapdf)
 
 
 def test_evolve_pdfs_dump_file(fake_lhapdf, cd):

--- a/tests/ekobox/test_info_file.py
+++ b/tests/ekobox/test_info_file.py
@@ -1,7 +1,6 @@
 import math
 
 import numpy as np
-import pytest
 
 from ekobox import cards, info_file
 
@@ -34,12 +33,12 @@ def test_build_alphas_good():
     op = cards.example.operator()
     op.mu0 = 1.0
     # base case
-    op.mugrid = [(10.0, 5), (100.0, 5)]
+    op.mugrid = [(100.0, 5), (10.0, 5)]
     info = info_file.build_alphas(theory, op)
     assert len(info["AlphaS_Vals"]) == 2
     np.testing.assert_allclose(info["AlphaS_Qs"], [10.0, 100.0])
     # several nf
-    op.mugrid = [(1.0, 3), (5.0, 3), (5.0, 4), (10.0, 5), (10.0, 5), (100.0, 5)]
+    op.mugrid = [(5.0, 4), (10.0, 5), (1.0, 3), (5.0, 3), (10.0, 5), (100.0, 5)]
     info = info_file.build_alphas(theory, op)
     assert len(info["AlphaS_Vals"]) == 6
     np.testing.assert_allclose(info["AlphaS_Qs"], [1.0, 5.0, 5.0, 10.0, 10.0, 100.0])
@@ -48,18 +47,3 @@ def test_build_alphas_good():
     info = info_file.build_alphas(theory, op)
     assert len(info["AlphaS_Vals"]) == 4
     np.testing.assert_allclose(info["AlphaS_Qs"], [1.0, 10.0, 10.0, 100.0])
-
-
-def test_build_alphas_bad():
-    """Bad configurations."""
-    theory = cards.example.theory()
-    theory.order = (2, 0)
-    theory.couplings.alphas = 0.2
-    op = cards.example.operator()
-    op.mu0 = 1.0
-    op.mugrid = [(5.0, 3), (15.0, 4), (10.0, 5), (100.0, 5)]
-    with pytest.raises(ValueError, match="is bigger"):
-        info_file.build_alphas(theory, op)
-    op.mugrid = [(5.0, 3), (10.0, 3), (10.0, 4), (15.0, 4), (10.0, 5)]
-    with pytest.raises(ValueError, match="is bigger"):
-        info_file.build_alphas(theory, op)

--- a/tests/ekobox/test_info_file.py
+++ b/tests/ekobox/test_info_file.py
@@ -1,6 +1,7 @@
 import math
 
 import numpy as np
+import pytest
 
 from ekobox import cards, info_file
 
@@ -23,3 +24,42 @@ def test_build():
     np.testing.assert_allclose(info["QMin"], math.sqrt(op.mu2grid[0]), rtol=1e-5)
     assert info["XMin"] == op.xgrid.raw[0]
     assert info["XMax"] == op.xgrid.raw[-1] == 1.0
+
+
+def test_build_alphas_good():
+    """Good configurations."""
+    theory = cards.example.theory()
+    theory.order = (2, 0)
+    theory.couplings.alphas = 0.2
+    op = cards.example.operator()
+    op.mu0 = 1.0
+    # base case
+    op.mugrid = [(10.0, 5), (100.0, 5)]
+    info = info_file.build_alphas(theory, op)
+    assert len(info["AlphaS_Vals"]) == 2
+    np.testing.assert_allclose(info["AlphaS_Qs"], [10.0, 100.0])
+    # several nf
+    op.mugrid = [(1.0, 3), (5.0, 3), (5.0, 4), (10.0, 5), (10.0, 5), (100.0, 5)]
+    info = info_file.build_alphas(theory, op)
+    assert len(info["AlphaS_Vals"]) == 6
+    np.testing.assert_allclose(info["AlphaS_Qs"], [1.0, 5.0, 5.0, 10.0, 10.0, 100.0])
+    # several nf with gap
+    op.mugrid = [(1.0, 3), (10.0, 3), (10.0, 5), (100.0, 5)]
+    info = info_file.build_alphas(theory, op)
+    assert len(info["AlphaS_Vals"]) == 4
+    np.testing.assert_allclose(info["AlphaS_Qs"], [1.0, 10.0, 10.0, 100.0])
+
+
+def test_build_alphas_bad():
+    """Bad configurations."""
+    theory = cards.example.theory()
+    theory.order = (2, 0)
+    theory.couplings.alphas = 0.2
+    op = cards.example.operator()
+    op.mu0 = 1.0
+    op.mugrid = [(5.0, 3), (15.0, 4), (10.0, 5), (100.0, 5)]
+    with pytest.raises(ValueError, match="is bigger"):
+        info_file.build_alphas(theory, op)
+    op.mugrid = [(5.0, 3), (10.0, 3), (10.0, 4), (15.0, 4), (10.0, 5)]
+    with pytest.raises(ValueError, match="is bigger"):
+        info_file.build_alphas(theory, op)


### PR DESCRIPTION
The information about nf is not utilized when generating the info files. This PR fixes that.
evolven3fit relies on eko for the info file so once this is merged into a release of eko it should work fine.

Apparently LHAPDF doesn't have a block mechanism for `alpha_s` so at the moment we just provide two values for two nfs for the same Q at the thresholds.

(As far as I can see, the same problem was there in NNPDF4.0 -apfel + evolven3fit- and NNPDF3.1 -apfel + evolvennfit-, so nobody ever noticed...)