### PR TITLE
Remove `ev_op_iterations` from truncated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+We may prefix the items to signal the scope:
+
+- py: Python library
+- rust: Rust library
+
+Items without prefix refer to a global change.
+
+## [Unreleased](https://github.com/NNPDF/eko/compare/v0.15.1...HEAD)
+
+### Fixed
+- py: Remove usage of `ev_op_iterations` from truncated evolution as this is an inconsistent choice ([#459](https://github.com/NNPDF/eko/pull/459))
+
+## [0.15.1](https://github.com/NNPDF/eko/compare/v0.15.0...v0.15.1) - 2025-03-20
+
+### Fixed
+- py: Fix Python release workflow by explicitly downloading the test data
+- py: Resolve files in output to actually edit the true file
+
+## [0.15.0](https://github.com/NNPDF/eko/compare/v0.14.6...v0.15.0) - 2025-03-06

--- a/src/eko/evolution_operator/__init__.py
+++ b/src/eko/evolution_operator/__init__.py
@@ -442,7 +442,6 @@ def quad_ker_qcd(
             as1,
             as0,
             nf,
-            ev_op_iterations,
         )
         if sv_mode == sv.Modes.expanded and not is_threshold:
             ker = sv_expanded.non_singlet_variation(gamma_ns, as1, order, nf, L) * ker

--- a/src/eko/evolution_operator/quad_ker.py
+++ b/src/eko/evolution_operator/quad_ker.py
@@ -170,7 +170,6 @@ def cb_quad_ker_qcd(
             as1,
             as0,
             nf,
-            ev_op_iterations,
         )
         if sv_mode == sv.Modes.expanded and not is_threshold:
             ker = sv_expanded.non_singlet_variation(gamma_ns, as1, order, nf, Lsv) * ker

--- a/src/eko/kernels/non_singlet.py
+++ b/src/eko/kernels/non_singlet.py
@@ -276,14 +276,12 @@ def eko_ordered_truncated(gamma_ns, a1, a0, beta, order):
         non-singlet ordered truncated EKO
     """
     U = U_vec(gamma_ns, beta, order)
-    e = 1.0
     e0 = lo_exact(gamma_ns, a1, a0, beta)
     num, den = 0, 0
     for i in range(order[0]):
         num += U[i] * a1**i
         den += U[i] * a0**i
-    e *= e0 * num / den
-    return e
+    return e0 * num / den
 
 
 @nb.njit(cache=True)
@@ -309,7 +307,6 @@ def eko_truncated(gamma_ns, a1, a0, beta, order):
         non-singlet truncated EKO
     """
     U = U_vec(gamma_ns, beta, order)
-    e = 1.0
     fact = U[0]
     e0 = lo_exact(gamma_ns, a1, a0, beta)
     if order[0] >= 2:
@@ -323,8 +320,7 @@ def eko_truncated(gamma_ns, a1, a0, beta, order):
             + a1 * a0**2 * U[1] * (U[1] ** 2 - U[2])
             - a0**3 * (U[1] ** 3 - 2 * U[1] * U[2] + U[3])
         )
-    e *= e0 * fact
-    return e
+    return e0 * fact
 
 
 @nb.njit(cache=True)

--- a/src/eko/kernels/singlet.py
+++ b/src/eko/kernels/singlet.py
@@ -539,23 +539,21 @@ def eko_truncated(gamma_singlet, a1, a0, beta, order):
     r = r_vec(gamma_singlet, beta, order, order, False)
     u = u_vec(r, order)
     u1 = np.ascontiguousarray(u[1])
-    e = np.identity(2, np.complex_)
-    # iterate elements
     e0 = np.ascontiguousarray(lo_exact(gamma_singlet, a1, a0, beta))
+    e = e0
     if order[0] >= 2:
-        ek = e0 + a1 * u1 @ e0 - a0 * e0 @ u1
+        e += a1 * u1 @ e0 - a0 * e0 @ u1
     if order[0] >= 3:
         u2 = np.ascontiguousarray(u[2])
-        ek += +(a1**2) * u2 @ e0 - a1 * a0 * u1 @ e0 @ u1 + a0**2 * e0 @ (u1 @ u1 - u2)
+        e += +(a1**2) * u2 @ e0 - a1 * a0 * u1 @ e0 @ u1 + a0**2 * e0 @ (u1 @ u1 - u2)
     if order[0] >= 4:
         u3 = np.ascontiguousarray(u[3])
-        ek += (
+        e += (
             +(a1**3) * u3 @ e0
             - a1**2 * a0 * u2 @ e0 @ u1
             + a1 * a0**2 * u1 @ e0 @ (u1 @ u1 - u2)
             - a0**3 * e0 @ (u1 @ u1 @ u1 - u1 @ u2 - u2 @ u1 + u3)
         )
-    e = ek @ e
     return e
 
 

--- a/tests/eko/evolution_operator/test_init.py
+++ b/tests/eko/evolution_operator/test_init.py
@@ -440,7 +440,6 @@ def test_pegasus_path():
             a1,
             a0,
             nf,
-            ev_op_iterations,
         )
         pj = interpolation.log_evaluate_Nx(n, logx, areas)
         return np.imag(np.exp(1j * phi) / np.pi * pj * ker)

--- a/tests/eko/kernels/test_ns.py
+++ b/tests/eko/kernels/test_ns.py
@@ -12,14 +12,11 @@ from eko.kernels import non_singlet as ns
 def test_zero():
     """No evolution results in exp(0)"""
     nf = 3
-    ev_op_iterations = 2
     gamma_ns = np.array([1 + 0.0j, 1 + 0j, 1 + 0j, 1 + 0j])
     for order in [1, 2, 3, 4]:
         for method in EvoMethods:
             np.testing.assert_allclose(
-                ns.dispatcher(
-                    (order, 0), method, gamma_ns, 1.0, 1.0, nf, ev_op_iterations
-                ),
+                ns.dispatcher((order, 0), method, gamma_ns, 1.0, 1.0, nf),
                 1.0,
             )
             np.testing.assert_allclose(
@@ -30,7 +27,6 @@ def test_zero():
                     2.0,
                     1.0,
                     nf,
-                    ev_op_iterations,
                 ),
                 1.0,
             )
@@ -38,16 +34,13 @@ def test_zero():
 
 def test_ode_lo():
     nf = 3
-    ev_op_iterations = 10
     gamma_ns = np.random.rand(1) + 0j
     delta_a = -1e-6
     a0 = 0.3
     for a1 in [0.1, 0.2]:
         r = a1 * gamma_ns / (beta.beta_qcd((2, 0), nf) * a1**2)
         for method in EvoMethods:
-            rhs = r * ns.dispatcher(
-                (1, 0), method, gamma_ns, a1, a0, nf, ev_op_iterations
-            )
+            rhs = r * ns.dispatcher((1, 0), method, gamma_ns, a1, a0, nf)
             lhs = (
                 ns.dispatcher(
                     (1, 0),
@@ -56,7 +49,6 @@ def test_ode_lo():
                     a1 + 0.5 * delta_a,
                     a0,
                     nf,
-                    ev_op_iterations,
                 )
                 - ns.dispatcher(
                     (1, 0),
@@ -65,7 +57,6 @@ def test_ode_lo():
                     a1 - 0.5 * delta_a,
                     a0,
                     nf,
-                    ev_op_iterations,
                 )
             ) / delta_a
             np.testing.assert_allclose(lhs, rhs, atol=np.abs(delta_a))
@@ -73,7 +64,6 @@ def test_ode_lo():
 
 def test_ode_nlo():
     nf = 3
-    ev_op_iterations = 10
     gamma_ns = np.random.rand(2) + 0j
     delta_a = -1e-6
     a0 = 0.3
@@ -82,9 +72,7 @@ def test_ode_nlo():
             beta.beta_qcd((2, 0), nf) * a1**2 + beta.beta_qcd((3, 0), nf) * a1**3
         )
         for method in [EvoMethods.ITERATE_EXACT]:
-            rhs = r * ns.dispatcher(
-                (2, 0), method, gamma_ns, a1, a0, nf, ev_op_iterations
-            )
+            rhs = r * ns.dispatcher((2, 0), method, gamma_ns, a1, a0, nf)
             lhs = (
                 ns.dispatcher(
                     (2, 0),
@@ -93,7 +81,6 @@ def test_ode_nlo():
                     a1 + 0.5 * delta_a,
                     a0,
                     nf,
-                    ev_op_iterations,
                 )
                 - ns.dispatcher(
                     (2, 0),
@@ -102,7 +89,6 @@ def test_ode_nlo():
                     a1 - 0.5 * delta_a,
                     a0,
                     nf,
-                    ev_op_iterations,
                 )
             ) / delta_a
             np.testing.assert_allclose(lhs, rhs, atol=np.abs(delta_a))
@@ -110,7 +96,6 @@ def test_ode_nlo():
 
 def test_ode_nnlo():
     nf = 3
-    ev_op_iterations = 10
     gamma_ns = np.random.rand(3) + 0j
     delta_a = -1e-6
     a0 = 0.3
@@ -121,35 +106,16 @@ def test_ode_nnlo():
             + beta.beta_qcd((4, 0), nf) * a1**3
         )
         for method in [EvoMethods.ITERATE_EXACT]:
-            rhs = r * ns.dispatcher(
-                (3, 0), method, gamma_ns, a1, a0, nf, ev_op_iterations
-            )
+            rhs = r * ns.dispatcher((3, 0), method, gamma_ns, a1, a0, nf)
             lhs = (
-                ns.dispatcher(
-                    (3, 0),
-                    method,
-                    gamma_ns,
-                    a1 + 0.5 * delta_a,
-                    a0,
-                    nf,
-                    ev_op_iterations,
-                )
-                - ns.dispatcher(
-                    (3, 0),
-                    method,
-                    gamma_ns,
-                    a1 - 0.5 * delta_a,
-                    a0,
-                    nf,
-                    ev_op_iterations,
-                )
+                ns.dispatcher((3, 0), method, gamma_ns, a1 + 0.5 * delta_a, a0, nf)
+                - ns.dispatcher((3, 0), method, gamma_ns, a1 - 0.5 * delta_a, a0, nf)
             ) / delta_a
             np.testing.assert_allclose(lhs, rhs)
 
 
 def test_ode_n3lo():
     nf = 3
-    ev_op_iterations = 10
     gamma_ns = np.random.rand(4) + 0j
     delta_a = -1e-6
     a0 = 0.3
@@ -163,28 +129,10 @@ def test_ode_n3lo():
             + beta.beta_qcd((5, 0), nf) * a1**4
         )
         for method in [EvoMethods.ITERATE_EXACT]:
-            rhs = r * ns.dispatcher(
-                (4, 0), method, gamma_ns, a1, a0, nf, ev_op_iterations
-            )
+            rhs = r * ns.dispatcher((4, 0), method, gamma_ns, a1, a0, nf)
             lhs = (
-                ns.dispatcher(
-                    (4, 0),
-                    method,
-                    gamma_ns,
-                    a1 + 0.5 * delta_a,
-                    a0,
-                    nf,
-                    ev_op_iterations,
-                )
-                - ns.dispatcher(
-                    (4, 0),
-                    method,
-                    gamma_ns,
-                    a1 - 0.5 * delta_a,
-                    a0,
-                    nf,
-                    ev_op_iterations,
-                )
+                ns.dispatcher((4, 0), method, gamma_ns, a1 + 0.5 * delta_a, a0, nf)
+                - ns.dispatcher((4, 0), method, gamma_ns, a1 - 0.5 * delta_a, a0, nf)
             ) / delta_a
             np.testing.assert_allclose(lhs, rhs)
 
@@ -193,7 +141,7 @@ def test_error(monkeypatch):
     monkeypatch.setattr("eko.beta.beta_qcd", lambda *_args: 1.0)
     with pytest.raises(NotImplementedError, match="order is not implemented"):
         ns.dispatcher(
-            (5, 0), EvoMethods.ITERATE_EXACT, np.random.rand(3) + 0j, 0.2, 0.1, 3, 10
+            (5, 0), EvoMethods.ITERATE_EXACT, np.random.rand(3) + 0j, 0.2, 0.1, 3
         )
     with pytest.raises(NotImplementedError):
         ad.gamma_ns((2, 0), 10202, 1, (0, 0, 0, 0, 0, 0, 0), 3)
@@ -203,15 +151,12 @@ def test_gamma_usage():
     a1 = 0.1
     a0 = 0.3
     nf = 3
-    ev_op_iterations = 10
     # first check that at order=n only uses the matrices up n
     gamma_ns = np.full(4, np.nan)
     for order in range(1, 5):
         gamma_ns[order - 1] = np.random.rand()
         for method in EvoMethods:
-            r = ns.dispatcher(
-                (order, 0), method, gamma_ns, a1, a0, nf, ev_op_iterations
-            )
+            r = ns.dispatcher((order, 0), method, gamma_ns, a1, a0, nf)
             assert not np.isnan(r)
     # second check that at order=n the actual matrix n is used
     for order in range(1, 5):
@@ -222,7 +167,5 @@ def test_gamma_usage():
                 # we are actually dividing by a np.nan,
                 # since the sum of U vec is nan
                 warnings.simplefilter("ignore", RuntimeWarning)
-            r = ns.dispatcher(
-                (order, 0), method, gamma_ns, a1, a0, nf, ev_op_iterations
-            )
+            r = ns.dispatcher((order, 0), method, gamma_ns, a1, a0, nf)
             assert np.isnan(r)

--- a/tests/eko/scale_variations/test_diff.py
+++ b/tests/eko/scale_variations/test_diff.py
@@ -123,16 +123,12 @@ def test_scale_variation_a_vs_b():
                 )
 
                 # build scheme B solution
-                ker_b = non_singlet.dispatcher(
-                    order, EV_METHOD, gns, a1_b, a0_b, NF, ev_op_iterations=1
-                )
+                ker_b = non_singlet.dispatcher(order, EV_METHOD, gns, a1_b, a0_b, NF)
                 ker_b = ker_b * expanded.non_singlet_variation(gns, a1_b, order, NF, L)
 
                 # build scheme A solution
                 gns_a = exponentiated.gamma_variation(gns.copy(), order, NF, L)
-                ker_a = non_singlet.dispatcher(
-                    order, EV_METHOD, gns_a, a1_a, a0_a, NF, ev_op_iterations=1
-                )
+                ker_a = non_singlet.dispatcher(order, EV_METHOD, gns_a, a1_a, a0_a, NF)
 
                 ns_diff = scheme_diff_ns(gns, a0, a1, L, order)
                 np.testing.assert_allclose(

--- a/tests/eko/scale_variations/test_expanded.py
+++ b/tests/eko/scale_variations/test_expanded.py
@@ -136,12 +136,8 @@ def test_expanded_is_linear():
                 )
 
                 # build scheme B solution
-                ker_b = non_singlet.dispatcher(
-                    order, EV_METHOD, gns, a1, a0, NF, ev_op_iterations=1
-                )
-                sv_b = non_singlet.dispatcher(
-                    order, EV_METHOD, gns, a1_b, a0, NF, ev_op_iterations=1
-                )
+                ker_b = non_singlet.dispatcher(order, EV_METHOD, gns, a1, a0, NF)
+                sv_b = non_singlet.dispatcher(order, EV_METHOD, gns, a1_b, a0, NF)
                 sv_b = sv_b * expanded.non_singlet_variation(gns, a1_b, order, NF, L)
 
                 rel_err_ns.append(sv_b / ker_b)


### PR DESCRIPTION
Closes #447 

As a consequence `ev_op_iterations` also dropped from `kernels.ns.dispatcher`, i.e. in the non-singlet sector there is no iteration anywhere (since exact _is_ exact). This triggers a few more changes on the testing side.