### PR TITLE
ci: fix x86 cross-compilation linker and artifact syntax ;

### DIFF
--- a/.github/workflows/maturin.yml
+++ b/.github/workflows/maturin.yml
@@ -23,6 +23,11 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
+      - name: Install 32-bit glibc headers (x86 only)
+        if: matrix.platform.target == 'x86'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
@@ -114,6 +119,9 @@ jobs:
     needs: [linux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:


### PR DESCRIPTION
## Summary
As discussed in #502 , I've separated the immediate Maturin build fix from the OIDC in the PR ;

## Changes
1. Installs `gcc-multilib` conditionally for the Linux x86 target, resolving the `crti.o` linker error that was preventing compilation.
2. Updates `actions/download-artifact` syntax to v4 with the required `pattern:` block to resolve the failing release download step.

**Verification:**
I ran an end-to-end mock release on my fork using a dummy tag. 
* The x86 wheel compiles successfully (`readelf` confirms `Class: ELF32`).
* The v4 artifact step was sucessful, and 
* The test suite clears successfully;