### PR TITLE
Add centralised workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ repository = "https://github.com/NNPDF/eko"
 rust-version = "1.70.0"
 version = "0.0.1"
 
+# all dependencies should be collected here in the workspace
 [workspace.dependencies]
 # Internal crates
 ekore = { path = "crates/ekore", version = "0.0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,22 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/NNPDF/eko"
 rust-version = "1.70.0"
 version = "0.0.1"
+
+[workspace.dependencies]
+# Internal crates
+ekore = { path = "crates/ekore", version = "0.0.1" }
+
+# External dependencies
+lz4_flex = "0.11.6"
+ndarray = "0.15.4"
+ndarray-npy = "0.8.1"
+num = "0.4.1"
+tar = "0.4.46"
+thiserror = "1.0.63"
+yaml-rust2 = "0.8"
+
+# Dev dependencies
+assert_fs = "1.1.2"
+float-cmp = "0.9.0"
+GSL = "7.0"
+predicates = "3.1.2"

--- a/crates/bump-versions.py
+++ b/crates/bump-versions.py
@@ -10,13 +10,9 @@ CRATES = json.loads((HERE / "release.json").read_text())
 
 def workspace(manifest, version):
     manifest["workspace"]["package"]["version"] = version
-    return manifest
-
-
-def crate(manifest, version):
-    internals = set(manifest["dependencies"].keys()).intersection(CRATES)
+    internals = set(manifest["workspace"]["dependencies"].keys()).intersection(CRATES)
     for dep in internals:
-        manifest["dependencies"][dep]["version"] = version
+        manifest["workspace"]["dependencies"][dep]["version"] = version
     return manifest
 
 
@@ -29,8 +25,6 @@ def update(path, version, edit):
 
 def main(version):
     update("..", version, workspace)
-    for name in CRATES:
-        update(name, version, crate)
 
 
 if __name__ == "__main__":

--- a/crates/bump-versions.py
+++ b/crates/bump-versions.py
@@ -8,23 +8,14 @@ HERE = Path(__file__).parent
 CRATES = json.loads((HERE / "release.json").read_text())
 
 
-def workspace(manifest, version):
+def main(version):
+    path = HERE / ".." / "Cargo.toml"
+    manifest = tomlkit.parse(path.read_text())
     manifest["workspace"]["package"]["version"] = version
     internals = set(manifest["workspace"]["dependencies"].keys()).intersection(CRATES)
     for dep in internals:
         manifest["workspace"]["dependencies"][dep]["version"] = version
-    return manifest
-
-
-def update(path, version, edit):
-    path = HERE / Path(path) / "Cargo.toml"
-    manifest = tomlkit.parse(path.read_text())
-    manifest = edit(manifest, version)
     path.write_text(tomlkit.dumps(manifest))
-
-
-def main(version):
-    update("..", version, workspace)
 
 
 if __name__ == "__main__":

--- a/crates/dekoder/Cargo.toml
+++ b/crates/dekoder/Cargo.toml
@@ -16,13 +16,13 @@ version.workspace = true
 rustdoc-args = ["--html-in-header", "doc-header.html"]
 
 [dependencies]
-tar = "0.4.46"
-yaml-rust2 = "0.8"
-lz4_flex = "0.11.6"
-ndarray = "0.15.4"
-ndarray-npy = "0.8.1"
-thiserror = "1.0.63"
+tar.workspace = true
+yaml-rust2.workspace = true
+lz4_flex.workspace = true
+ndarray.workspace = true
+ndarray-npy.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
-assert_fs = "1.1.2"
-predicates = "3.1.2"
+assert_fs.workspace = true
+predicates.workspace = true

--- a/crates/eko/Cargo.toml
+++ b/crates/eko/Cargo.toml
@@ -20,5 +20,5 @@ name = "ekors"
 crate-type = ["cdylib"]
 
 [dependencies]
-num = "0.4.1"
-ekore = { path = "../ekore", version = "0.0.1" }
+num.workspace = true
+ekore.workspace = true

--- a/crates/ekore/Cargo.toml
+++ b/crates/ekore/Cargo.toml
@@ -18,8 +18,8 @@ rustdoc-args = ["--html-in-header", "doc-header.html"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-num = "0.4.1"
+num.workspace = true
 
 [dev-dependencies]
-float-cmp = "0.9.0"
-GSL = "7.0"
+float-cmp.workspace = true
+GSL.workspace = true


### PR DESCRIPTION
A prerequisite for #537.
- Adds dependencies to root `Cargo.toml`, and all crates point to that.