### PR TITLE
Update rust/ekore documentation

### DIFF
--- a/crates/doc-header.html
+++ b/crates/doc-header.html
@@ -53,7 +53,7 @@
         function replaceAbbrev(el) {
             let txt = el.innerHTML;
             for (k in parsedAbbrevs)
-                txt = txt.replace(k, parsedAbbrevs[k]);
+                txt = txt.replaceAll(k, parsedAbbrevs[k]);
             el.innerHTML = txt;
         }
         // search texts

--- a/crates/eko/src/lib.rs
+++ b/crates/eko/src/lib.rs
@@ -155,7 +155,6 @@ pub unsafe extern "C" fn rust_quad_ker(u: f64, rargs: *mut c_void) -> f64 {
                                 args.order_qcd,
                                 &mut c,
                                 args.nf,
-                                n3lo_ad_variation[0..4].try_into().unwrap(),
                             ),
                             args.order_qcd,
                             out_re,
@@ -220,7 +219,6 @@ pub unsafe extern "C" fn rust_quad_ker(u: f64, rargs: *mut c_void) -> f64 {
                         args.mode0,
                         &mut c,
                         args.nf,
-                        n3lo_ad_variation[4..7].try_into().unwrap(),
                     );
                     for (i, el) in res.iter().take(args.order_qcd).enumerate() {
                         out_re[i] = el.re;

--- a/crates/ekore/src/anomalous_dimensions/polarized/spacelike.rs
+++ b/crates/ekore/src/anomalous_dimensions/polarized/spacelike.rs
@@ -12,6 +12,11 @@ mod as2;
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2,)`. Only the first `order_qcd` entries
 /// are filled; remaining slots are zero.
+///
+/// # Available perturbative orders:
+///
+/// - $a_s^1$ [\[Moch:2004pa\]][crate::bib::Moch2004pa]
+/// - $a_s^2$ [\[Moch:2004pa\]][crate::bib::Moch2004pa]
 pub fn gamma_ns_qcd(
     order_qcd: usize,
     mode: u16,
@@ -51,6 +56,11 @@ pub fn gamma_ns_qcd(
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2, 2, 2)`. Only the first `order_qcd`
 /// entries along the outer axis are filled; remaining slots are zero.
+///
+/// # Available perturbative orders:
+///
+/// - $a_s^1$ [\[Gluck:1995yr\]][crate::bib::Gluck1995yr]
+/// - $a_s^2$ [\[Gluck:1995yr\]][crate::bib::Gluck1995yr] [\[Moch:2004pa\]][crate::bib::Moch2004pa]
 pub fn gamma_singlet_qcd(
     order_qcd: usize,
     cache: &mut Cache,

--- a/crates/ekore/src/anomalous_dimensions/polarized/spacelike.rs
+++ b/crates/ekore/src/anomalous_dimensions/polarized/spacelike.rs
@@ -17,6 +17,10 @@ mod as2;
 ///
 /// - $a_s^1$ [\[Moch:2004pa\]][crate::bib::Moch2004pa]
 /// - $a_s^2$ [\[Moch:2004pa\]][crate::bib::Moch2004pa]
+///
+/// # Panics
+///
+/// Panics if `order_qcd` is larger than the currently available order or `mode` is not a valid |PID|.
 pub fn gamma_ns_qcd(
     order_qcd: usize,
     mode: u16,
@@ -61,6 +65,10 @@ pub fn gamma_ns_qcd(
 ///
 /// - $a_s^1$ [\[Gluck:1995yr\]][crate::bib::Gluck1995yr]
 /// - $a_s^2$ [\[Gluck:1995yr\]][crate::bib::Gluck1995yr] [\[Moch:2004pa\]][crate::bib::Moch2004pa]
+///
+/// # Panics
+///
+/// Panics if `order_qcd` is larger than the currently available order.
 pub fn gamma_singlet_qcd(
     order_qcd: usize,
     cache: &mut Cache,

--- a/crates/ekore/src/anomalous_dimensions/polarized/spacelike.rs
+++ b/crates/ekore/src/anomalous_dimensions/polarized/spacelike.rs
@@ -1,4 +1,4 @@
-//! The polarized, space-like anomalous dimensions at various couplings power.
+//! The polarized, space-like anomalous dimensions.
 
 use crate::constants::{MAX_ORDER_QCD, PID_NSM, PID_NSP, PID_NSV};
 use crate::harmonics::cache::Cache;
@@ -8,14 +8,14 @@ mod as1;
 mod as2;
 // pub mod as3;
 
-/// Compute the tower of the non-singlet anomalous dimensions.
+/// Compute the tower of the polarized, space-like non-singlet anomalous dimensions.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2,)`. Only the first `order_qcd` entries
 /// are filled; remaining slots are zero.
 pub fn gamma_ns_qcd(
     order_qcd: usize,
     mode: u16,
-    c: &mut Cache,
+    cache: &mut Cache,
     nf: u8,
     _n3lo_variation: [u8; 3],
 ) -> [Complex<f64>; MAX_ORDER_QCD - 2] {
@@ -23,13 +23,13 @@ pub fn gamma_ns_qcd(
         panic!("Polarized beyond NLO is not yet implemented");
     }
     let mut gamma_ns = [Complex::<f64>::zero(); MAX_ORDER_QCD - 2];
-    gamma_ns[0] = as1::gamma_ns(c, nf);
+    gamma_ns[0] = as1::gamma_ns(cache, nf);
     // NLO and beyond
     if order_qcd >= 2 {
         let gamma_ns_1 = match mode {
-            PID_NSP => as2::gamma_nsp(c, nf),
+            PID_NSP => as2::gamma_nsp(cache, nf),
             // To fill the full valence vector in NNLO we need to add gamma_ns^1 explicitly here
-            PID_NSM | PID_NSV => as2::gamma_nsm(c, nf),
+            PID_NSM | PID_NSV => as2::gamma_nsm(cache, nf),
             _ => panic!("Unkown non-singlet sector element"),
         };
         gamma_ns[1] = gamma_ns_1
@@ -37,9 +37,9 @@ pub fn gamma_ns_qcd(
     // // NNLO and beyond
     // if order_qcd >= 3 {
     //     let gamma_ns_2 = match mode {
-    //         PID_NSP => as3::gamma_nsp(c, nf),
-    //         PID_NSM => as3::gamma_nsm(c, nf),
-    //         PID_NSV => as3::gamma_nsv(c, nf),
+    //         PID_NSP => as3::gamma_nsp(cache, nf),
+    //         PID_NSM => as3::gamma_nsm(cache, nf),
+    //         PID_NSV => as3::gamma_nsv(cache, nf),
     //         _ => panic!("Unkown non-singlet sector element"),
     //     };
     //     gamma_ns[2] = gamma_ns_2
@@ -47,13 +47,13 @@ pub fn gamma_ns_qcd(
     gamma_ns
 }
 
-/// Compute the tower of the singlet anomalous dimension matrices.
+/// Compute the tower of the polarized, space-like singlet anomalous dimension matrices.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2, 2, 2)`. Only the first `order_qcd`
 /// entries along the outer axis are filled; remaining slots are zero.
 pub fn gamma_singlet_qcd(
     order_qcd: usize,
-    c: &mut Cache,
+    cache: &mut Cache,
     nf: u8,
     _n3lo_variation: [u8; 4],
 ) -> [[[Complex<f64>; 2]; 2]; MAX_ORDER_QCD - 2] {
@@ -61,14 +61,14 @@ pub fn gamma_singlet_qcd(
         panic!("Polarized beyond NLO is not yet implemented");
     }
     let mut gamma_S = [[[Complex::<f64>::zero(); 2]; 2]; MAX_ORDER_QCD - 2];
-    gamma_S[0] = as1::gamma_singlet(c, nf);
+    gamma_S[0] = as1::gamma_singlet(cache, nf);
     // NLO and beyond
     if order_qcd >= 2 {
-        gamma_S[1] = as2::gamma_singlet(c, nf);
+        gamma_S[1] = as2::gamma_singlet(cache, nf);
     }
     // // NNLO and beyond
     // if order_qcd >= 3 {
-    //     gamma_S[2] = as3::gamma_singlet(c, nf);
+    //     gamma_S[2] = as3::gamma_singlet(cache, nf);
     // }
     gamma_S
 }
@@ -86,14 +86,14 @@ mod tests {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(2., 0.);
         for order_qcd in 1..=2usize {
-            let mut c = Cache::new(N);
-            let gamma_ns = gamma_ns_qcd(order_qcd, PID_NSP, &mut c, NF, [0u8; 3]);
+            let mut cache = Cache::new(N);
+            let gamma_ns = gamma_ns_qcd(order_qcd, PID_NSP, &mut cache, NF, [0u8; 3]);
             assert_eq!(gamma_ns.len(), MAX_ORDER_QCD - 2);
             // slots beyond order_qcd must be zero
             for item in gamma_ns.iter().skip(order_qcd) {
                 assert_approx_eq_cmplx!(f64, *item, cmplx!(0., 0.));
             }
-            let gamma_s = gamma_singlet_qcd(order_qcd, &mut c, NF, [0u8; 4]);
+            let gamma_s = gamma_singlet_qcd(order_qcd, &mut cache, NF, [0u8; 4]);
             assert_eq!(gamma_s.len(), MAX_ORDER_QCD - 2);
             assert_eq!(gamma_s[0].len(), 2);
             assert_eq!(gamma_s[0][0].len(), 2);
@@ -108,13 +108,13 @@ mod tests {
     fn test_gamma_ns_qcd() {
         const NF: u8 = 3;
         const N: Complex<f64> = cmplx!(1., 0.);
-        let mut c = Cache::new(N);
+        let mut cache = Cache::new(N);
         let n3lo_variation = [0u8; 3];
 
         // LO
         assert_approx_eq_cmplx!(
             f64,
-            gamma_ns_qcd(2, PID_NSP, &mut c, NF, n3lo_variation)[0],
+            gamma_ns_qcd(2, PID_NSP, &mut cache, NF, n3lo_variation)[0],
             cmplx!(0., 0.),
             epsilon = 1e-14
         );
@@ -122,7 +122,7 @@ mod tests {
         // NLO
         assert_approx_eq_cmplx_1d!(
             f64,
-            gamma_ns_qcd(2, PID_NSP, &mut c, NF, n3lo_variation),
+            gamma_ns_qcd(2, PID_NSP, &mut cache, NF, n3lo_variation),
             [cmplx!(0., 0.); 2],
             2,
             epsilon = 2e-6
@@ -138,8 +138,8 @@ mod tests {
 
         const NF: u8 = 5;
         const N: Complex<f64> = cmplx!(2., 0.);
-        let mut c = Cache::new(N);
-        let gamma_s = gamma_singlet_qcd(2, &mut c, NF, [0u8; 4]);
+        let mut cache = Cache::new(N);
+        let gamma_s = gamma_singlet_qcd(2, &mut cache, NF, [0u8; 4]);
 
         // LO
         assert_approx_eq_cmplx!(
@@ -175,9 +175,9 @@ mod tests {
         use crate::constants::PID_NSM_U;
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(1.234, 0.);
-        let mut c = Cache::new(N);
+        let mut cache = Cache::new(N);
         // PID_NSM_U (10202) is not a valid mode for polarized non-singlet
-        gamma_ns_qcd(2, PID_NSM_U, &mut c, NF, [0u8; 3]);
+        gamma_ns_qcd(2, PID_NSM_U, &mut cache, NF, [0u8; 3]);
     }
 
     #[test]
@@ -185,8 +185,8 @@ mod tests {
     fn test_gamma_ns_order4_panics() {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(1.234, 0.);
-        let mut c = Cache::new(N);
-        gamma_ns_qcd(3, PID_NSM, &mut c, NF, [0u8; 3]);
+        let mut cache = Cache::new(N);
+        gamma_ns_qcd(3, PID_NSM, &mut cache, NF, [0u8; 3]);
     }
 
     #[test]
@@ -194,7 +194,7 @@ mod tests {
     fn test_gamma_singlet_order4_panics() {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(2.345, 0.);
-        let mut c = Cache::new(N);
-        gamma_singlet_qcd(3, &mut c, NF, [0u8; 4]);
+        let mut cache = Cache::new(N);
+        gamma_singlet_qcd(3, &mut cache, NF, [0u8; 4]);
     }
 }

--- a/crates/ekore/src/anomalous_dimensions/polarized/spacelike.rs
+++ b/crates/ekore/src/anomalous_dimensions/polarized/spacelike.rs
@@ -11,10 +11,7 @@ mod as2;
 /// Compute the tower of the polarized, space-like non-singlet anomalous dimensions.
 ///
 /// This function computes the first `order_qcd` entries for the |PID| `mode` at the Mellin variable
-/// set in `cache` using `nf` light flavors. `_n3lo_variation = (ns_p, ns_m, ns_v)` is a list with three
-/// entries indicating which |N3LO| variation should be used (if requested) for the given `mode`, where
-/// values `1` or `2` indicate the upper or lower bound respectively, while any other value returns the
-/// central (averaged) value.
+/// set in `cache` using `nf` light flavors.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2,)`. Only the first `order_qcd` entries
 /// are filled; remaining slots are zero.
@@ -32,7 +29,6 @@ pub fn gamma_ns_qcd(
     mode: u16,
     cache: &mut Cache,
     nf: u8,
-    _n3lo_variation: [u8; 3],
 ) -> [Complex<f64>; MAX_ORDER_QCD - 2] {
     if order_qcd >= 3 {
         panic!("Polarized beyond NLO is not yet implemented");
@@ -65,9 +61,7 @@ pub fn gamma_ns_qcd(
 /// Compute the tower of the polarized, space-like singlet anomalous dimension matrices.
 ///
 /// This function computes the first `order_qcd` entries at the Mellin variable set in `cache` using `nf`
-/// light flavors. `_n3lo_variation = (gg, gq, qg, qq)` is a list with four entries indicating which
-/// |N3LO| variation should be used (if requested), where values `1` or `2` indicate the upper or lower
-/// bound respectively, while any other value returns the central (averaged) value.
+/// light flavors.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2, 2, 2)`. Only the first `order_qcd`
 /// entries along the outer axis are filled; remaining slots are zero.
@@ -84,7 +78,6 @@ pub fn gamma_singlet_qcd(
     order_qcd: usize,
     cache: &mut Cache,
     nf: u8,
-    _n3lo_variation: [u8; 4],
 ) -> [[[Complex<f64>; 2]; 2]; MAX_ORDER_QCD - 2] {
     if order_qcd >= 3 {
         panic!("Polarized beyond NLO is not yet implemented");
@@ -116,13 +109,13 @@ mod tests {
         const N: Complex<f64> = cmplx!(2., 0.);
         for order_qcd in 1..=2usize {
             let mut cache = Cache::new(N);
-            let gamma_ns = gamma_ns_qcd(order_qcd, PID_NSP, &mut cache, NF, [0u8; 3]);
+            let gamma_ns = gamma_ns_qcd(order_qcd, PID_NSP, &mut cache, NF);
             assert_eq!(gamma_ns.len(), MAX_ORDER_QCD - 2);
             // slots beyond order_qcd must be zero
             for item in gamma_ns.iter().skip(order_qcd) {
                 assert_approx_eq_cmplx!(f64, *item, cmplx!(0., 0.));
             }
-            let gamma_s = gamma_singlet_qcd(order_qcd, &mut cache, NF, [0u8; 4]);
+            let gamma_s = gamma_singlet_qcd(order_qcd, &mut cache, NF);
             assert_eq!(gamma_s.len(), MAX_ORDER_QCD - 2);
             assert_eq!(gamma_s[0].len(), 2);
             assert_eq!(gamma_s[0][0].len(), 2);
@@ -138,12 +131,11 @@ mod tests {
         const NF: u8 = 3;
         const N: Complex<f64> = cmplx!(1., 0.);
         let mut cache = Cache::new(N);
-        let n3lo_variation = [0u8; 3];
 
         // LO
         assert_approx_eq_cmplx!(
             f64,
-            gamma_ns_qcd(2, PID_NSP, &mut cache, NF, n3lo_variation)[0],
+            gamma_ns_qcd(2, PID_NSP, &mut cache, NF)[0],
             cmplx!(0., 0.),
             epsilon = 1e-14
         );
@@ -151,7 +143,7 @@ mod tests {
         // NLO
         assert_approx_eq_cmplx_1d!(
             f64,
-            gamma_ns_qcd(2, PID_NSP, &mut cache, NF, n3lo_variation),
+            gamma_ns_qcd(2, PID_NSP, &mut cache, NF),
             [cmplx!(0., 0.); 2],
             2,
             epsilon = 2e-6
@@ -168,7 +160,7 @@ mod tests {
         const NF: u8 = 5;
         const N: Complex<f64> = cmplx!(2., 0.);
         let mut cache = Cache::new(N);
-        let gamma_s = gamma_singlet_qcd(2, &mut cache, NF, [0u8; 4]);
+        let gamma_s = gamma_singlet_qcd(2, &mut cache, NF);
 
         // LO
         assert_approx_eq_cmplx!(
@@ -206,7 +198,7 @@ mod tests {
         const N: Complex<f64> = cmplx!(1.234, 0.);
         let mut cache = Cache::new(N);
         // PID_NSM_U (10202) is not a valid mode for polarized non-singlet
-        gamma_ns_qcd(2, PID_NSM_U, &mut cache, NF, [0u8; 3]);
+        gamma_ns_qcd(2, PID_NSM_U, &mut cache, NF);
     }
 
     #[test]
@@ -215,7 +207,7 @@ mod tests {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(1.234, 0.);
         let mut cache = Cache::new(N);
-        gamma_ns_qcd(3, PID_NSM, &mut cache, NF, [0u8; 3]);
+        gamma_ns_qcd(3, PID_NSM, &mut cache, NF);
     }
 
     #[test]
@@ -224,6 +216,6 @@ mod tests {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(2.345, 0.);
         let mut cache = Cache::new(N);
-        gamma_singlet_qcd(3, &mut cache, NF, [0u8; 4]);
+        gamma_singlet_qcd(3, &mut cache, NF);
     }
 }

--- a/crates/ekore/src/anomalous_dimensions/polarized/spacelike.rs
+++ b/crates/ekore/src/anomalous_dimensions/polarized/spacelike.rs
@@ -10,6 +10,12 @@ mod as2;
 
 /// Compute the tower of the polarized, space-like non-singlet anomalous dimensions.
 ///
+/// This function computes the first `order_qcd` entries for the |PID| `mode` at the Mellin variable
+/// set in `cache` using `nf` light flavors. `_n3lo_variation = (ns_p, ns_m, ns_v)` is a list with three
+/// entries indicating which |N3LO| variation should be used (if requested) for the given `mode`, where
+/// values `1` or `2` indicate the upper or lower bound respectively, while any other value returns the
+/// central (averaged) value.
+///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2,)`. Only the first `order_qcd` entries
 /// are filled; remaining slots are zero.
 ///
@@ -57,6 +63,11 @@ pub fn gamma_ns_qcd(
 }
 
 /// Compute the tower of the polarized, space-like singlet anomalous dimension matrices.
+///
+/// This function computes the first `order_qcd` entries at the Mellin variable set in `cache` using `nf`
+/// light flavors. `_n3lo_variation = (gg, gq, qg, qq)` is a list with four entries indicating which
+/// |N3LO| variation should be used (if requested), where values `1` or `2` indicate the upper or lower
+/// bound respectively, while any other value returns the central (averaged) value.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2, 2, 2)`. Only the first `order_qcd`
 /// entries along the outer axis are filled; remaining slots are zero.

--- a/crates/ekore/src/anomalous_dimensions/unpolarized/spacelike.rs
+++ b/crates/ekore/src/anomalous_dimensions/unpolarized/spacelike.rs
@@ -28,10 +28,9 @@ mod as4;
 /// # Available perturbative orders:
 ///
 /// - $a_s^1$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
-/// - $a_{em}^1$ [\[Carrazza:2015dea\]][crate::bib::Carrazza2015dea]
 /// - $a_s^2$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
-/// - $a_{em}^2$ [\[deFlorian:2016gvk\]][crate::bib::deFlorian2016gvk]
 /// - $a_s^3$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
+/// - $a_S^4$ [\[Moch:2017uml\]][crate::bib::Moch2017uml]
 ///
 /// # Panics
 ///
@@ -89,6 +88,15 @@ pub fn gamma_ns_qcd(
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD, 2, 2)`. Only the first `order_qcd`
 /// entries along the outer axis are filled; remaining slots are zero.
+///
+/// # Available perturbative orders:
+///
+/// - $a_s^1$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
+/// - $a_s^2$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
+/// - $a_s^3$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
+/// - $a_S^4$ [\[Falcioni:2024qpd\]][crate::bib::Falcioni2024qpd] [\[Falcioni:2024xyt\]][crate::bib::Falcioni2024xyt]
+///   [\[Falcioni:2023luc\]][crate::bib::Falcioni2023luc] [\[Falcioni:2023vqq\]][crate::bib::Falcioni2023vqq]
+///   [\[Moch:2017uml\]][crate::bib::Moch2017uml]
 pub fn gamma_singlet_qcd(
     order_qcd: usize,
     cache: &mut Cache,
@@ -124,6 +132,12 @@ pub fn gamma_singlet_qcd(
 /// Returns an array of shape `(MAX_ORDER_QCD+1, MAX_ORDER_QED+1)`. The first
 /// `order_qcd + 1` entries along the QCD axis and `order_qed + 1` along the QED axis
 /// are filled; remaining slots are zero.
+///
+/// # Available perturbative orders:
+///
+/// - $a_{em}^1$ [\[Carrazza:2015dea\]][crate::bib::Carrazza2015dea]
+/// - $a_{em}^2$ [\[deFlorian:2016gvk\]][crate::bib::deFlorian2016gvk]
+/// - $a_s^1a_{em}^1$ [\[deFlorian:2015ujt\]][crate::bib::deFlorian2015ujt]
 pub fn gamma_ns_qed(
     order_qcd: usize,
     order_qed: usize,
@@ -185,6 +199,18 @@ pub fn gamma_ns_qed(
 /// Returns an array of shape `(MAX_ORDER_QCD+1, MAX_ORDER_QED+1, 4, 4)`. The first
 /// `order_qcd + 1` entries along the QCD axis and `order_qed + 1` along the QED axis
 /// are filled; remaining slots are zero.
+///
+/// # Available perturbative orders:
+///
+/// - $a_s^1$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
+/// - $a_{em}^1$ [\[Carrazza:2015dea\]][crate::bib::Carrazza2015dea]
+/// - $a_s^2$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
+/// - $a_{em}^2$ [\[deFlorian:2016gvk\]][crate::bib::deFlorian2016gvk]
+/// - $a_s^1a_{em}^1$ [\[deFlorian:2015ujt\]][crate::bib::deFlorian2015ujt]
+/// - $a_s^3$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
+/// - $a_S^4$ [\[Falcioni:2024qpd\]][crate::bib::Falcioni2024qpd] [\[Falcioni:2024xyt\]][crate::bib::Falcioni2024xyt]
+///   [\[Falcioni:2023luc\]][crate::bib::Falcioni2023luc] [\[Falcioni:2023vqq\]][crate::bib::Falcioni2023vqq]
+///   [\[Moch:2017uml\]][crate::bib::Moch2017uml]
 pub fn gamma_singlet_qed(
     order_qcd: usize,
     order_qed: usize,
@@ -262,6 +288,16 @@ pub fn gamma_singlet_qed(
 /// Returns an array of shape `(MAX_ORDER_QCD+1, MAX_ORDER_QED+1, 2, 2)`. The first
 /// `order_qcd + 1` entries along the QCD axis and `order_qed + 1` along the QED axis
 /// are filled; remaining slots are zero.
+///
+/// # Available perturbative orders:
+///
+/// - $a_s^1$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
+/// - $a_{em}^1$ [\[Carrazza:2015dea\]][crate::bib::Carrazza2015dea]
+/// - $a_s^2$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
+/// - $a_{em}^2$ [\[deFlorian:2016gvk\]][crate::bib::deFlorian2016gvk]
+/// - $a_s^1a_{em}^1$ [\[deFlorian:2015ujt\]][crate::bib::deFlorian2015ujt]
+/// - $a_s^3$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
+/// - $a_S^4$ [\[Moch:2017uml\]][crate::bib::Moch2017uml]
 pub fn gamma_valence_qed(
     order_qcd: usize,
     order_qed: usize,

--- a/crates/ekore/src/anomalous_dimensions/unpolarized/spacelike.rs
+++ b/crates/ekore/src/anomalous_dimensions/unpolarized/spacelike.rs
@@ -1,4 +1,4 @@
-//! The unpolarized, space-like anomalous dimensions at various couplings power.
+//! The unpolarized, space-like anomalous dimensions.
 
 use crate::constants::{
     ED2, EU2, MAX_ORDER_QCD, MAX_ORDER_QED, PID_NSM, PID_NSM_D, PID_NSM_U, PID_NSP, PID_NSP_D,
@@ -15,18 +15,31 @@ pub(crate) mod as2;
 mod as3;
 mod as4;
 
-/// Compute the tower of the non-singlet anomalous dimensions.
+/// Compute the tower of the unpolarized, space-like non-singlet anomalous dimensions.
 ///
-/// `n3lo_variation = (ns_p, ns_m, ns_v)` is a list indicating which variation should
-/// be used. `variation = 1,2` is the upper/lower bound, while any other value
+/// This function computes the first `order_qcd` entries for the |PID| `mode` at the Mellin variable set in `cache` using `nf` light flavors.
+/// `n3lo_variation = (ns_p, ns_m, ns_v)` is a list with three entries indicating which |N3LO| variation should
+/// be used (if requested) for the given `mode`, where values `1` or `2` indicate the upper or lower bound respectively, while any other value
 /// returns the central (averaged) value.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD,)`. Only the first `order_qcd` entries
 /// are filled; remaining slots are zero.
+///
+/// # Available perturbative orders:
+///
+/// - $a_s^1$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
+/// - $a_{em}^1$ [\[Carrazza:2015dea\]][crate::bib::Carrazza2015dea]
+/// - $a_s^2$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
+/// - $a_{em}^2$ [\[deFlorian:2016gvk\]][crate::bib::deFlorian2016gvk]
+/// - $a_s^3$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
+///
+/// # Panics
+///
+/// Panics if `order_qcd` is larger than the currently available order or `mode` is not a valid |PID|.
 pub fn gamma_ns_qcd(
     order_qcd: usize,
     mode: u16,
-    c: &mut Cache,
+    cache: &mut Cache,
     nf: u8,
     n3lo_variation: [u8; 3],
 ) -> [Complex<f64>; MAX_ORDER_QCD] {
@@ -34,13 +47,13 @@ pub fn gamma_ns_qcd(
         panic!("QCD beyond N3LO is not implemented");
     }
     let mut gamma_ns = [Complex::<f64>::zero(); MAX_ORDER_QCD];
-    gamma_ns[0] = as1::gamma_ns(c, nf);
+    gamma_ns[0] = as1::gamma_ns(cache, nf);
     // NLO and beyond
     if order_qcd >= 2 {
         let gamma_ns_1 = match mode {
-            PID_NSP => as2::gamma_nsp(c, nf),
+            PID_NSP => as2::gamma_nsp(cache, nf),
             // To fill the full valence vector in NNLO we need to add gamma_ns^1 explicitly here
-            PID_NSM | PID_NSV => as2::gamma_nsm(c, nf),
+            PID_NSM | PID_NSV => as2::gamma_nsm(cache, nf),
             _ => panic!("Unknown non-singlet sector element"),
         };
         gamma_ns[1] = gamma_ns_1
@@ -48,9 +61,9 @@ pub fn gamma_ns_qcd(
     // NNLO and beyond
     if order_qcd >= 3 {
         let gamma_ns_2 = match mode {
-            PID_NSP => as3::gamma_nsp(c, nf),
-            PID_NSM => as3::gamma_nsm(c, nf),
-            PID_NSV => as3::gamma_nsv(c, nf),
+            PID_NSP => as3::gamma_nsp(cache, nf),
+            PID_NSM => as3::gamma_nsm(cache, nf),
+            PID_NSV => as3::gamma_nsv(cache, nf),
             _ => panic!("Unknown non-singlet sector element"),
         };
         gamma_ns[2] = gamma_ns_2
@@ -58,9 +71,9 @@ pub fn gamma_ns_qcd(
     // N3LO and beyond
     if order_qcd >= 4 {
         let gamma_ns_3 = match mode {
-            PID_NSP => as4::gamma_nsp(c, nf, n3lo_variation[0]),
-            PID_NSM => as4::gamma_nsm(c, nf, n3lo_variation[1]),
-            PID_NSV => as4::gamma_nsv(c, nf, n3lo_variation[2]),
+            PID_NSP => as4::gamma_nsp(cache, nf, n3lo_variation[0]),
+            PID_NSM => as4::gamma_nsm(cache, nf, n3lo_variation[1]),
+            PID_NSV => as4::gamma_nsv(cache, nf, n3lo_variation[2]),
             _ => panic!("Unknown non-singlet sector element"),
         };
         gamma_ns[3] = gamma_ns_3

--- a/crates/ekore/src/anomalous_dimensions/unpolarized/spacelike.rs
+++ b/crates/ekore/src/anomalous_dimensions/unpolarized/spacelike.rs
@@ -82,8 +82,9 @@ pub fn gamma_ns_qcd(
 
 /// Compute the tower of the unpolarized, space-like singlet anomalous dimension matrices.
 ///
-/// `n3lo_variation = (gg, gq, qg, qq)` is a list indicating which variation should
-/// be used. `variation = 1,2` is the upper/lower bound, while any other value
+/// This function computes the first `order_qcd` entries at the Mellin variable set in `cache` using `nf` light flavors.
+/// `n3lo_variation = (gg, gq, qg, qq)` is a list with four entries indicating which |N3LO| variation should be used
+/// (if requested), where values `1` or `2` indicate the upper or lower bound respectively, while any other value
 /// returns the central (averaged) value.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD, 2, 2)`. Only the first `order_qcd`
@@ -129,9 +130,10 @@ pub fn gamma_singlet_qcd(
 
 /// Compute the tower of the |QCD| x |QED| unpolarized, space-like non-singlet anomalous dimensions.
 ///
-/// `n3lo_variation = (ns_p, ns_m, ns_v)` is a list indicating which variation should
-/// be used. `variation = 1,2` is the upper/lower bound, while any other value
-/// returns the central (averaged) value.
+/// This function computes the first `order_qcd` and `order_qed` entries for the |PID| `mode` at the Mellin variable
+/// set in `cache` using `nf` light flavors. `n3lo_variation = (ns_p, ns_m, ns_v)` is a list with three entries
+/// indicating which |N3LO| variation should be used (if requested) for the given `mode`, where values `1` or `2`
+/// indicate the upper or lower bound respectively, while any other value returns the central (averaged) value.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD+1, MAX_ORDER_QED+1)`. The first
 /// `order_qcd + 1` entries along the QCD axis and `order_qed + 1` along the QED axis
@@ -201,8 +203,9 @@ pub fn gamma_ns_qed(
 
 /// Compute the tower of the |QCD| x |QED| unpolarized, space-like singlet anomalous dimensions matrices.
 ///
-/// `n3lo_variation = (gg, gq, qg, qq, ns_p, ns_m, ns_v)` is a list indicating which variation should
-/// be used. `variation = 1,2` is the upper/lower bound, while any other value
+/// This function computes the first `order_qcd` and `order_qed` entries at the Mellin variable set in `cache` using `nf` light flavors.
+/// `n3lo_variation = (gg, gq, qg, qq, ns_p, ns_m, ns_v)` is a list with seven entries indicating which |N3LO| variation should
+/// be used (if requested), where values `1` or `2` indicate the upper or lower bound respectively, while any other value
 /// returns the central (averaged) value.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD+1, MAX_ORDER_QED+1, 4, 4)`. The first
@@ -294,9 +297,9 @@ pub fn gamma_singlet_qed(
 
 /// Compute the tower of the |QCD| x |QED| unpolarized, space-like valence anomalous dimensions matrices.
 ///
-/// `n3lo_variation = (ns_p, ns_m, ns_v)` is a list indicating which variation should
-/// be used. `variation = 1,2` is the upper/lower bound, while any other value
-/// returns the central (averaged) value.
+/// This function computes the first `order_qcd` and `order_qed` entries at the Mellin variable set in `cache` using `nf` light flavors.
+/// `n3lo_variation = (ns_p, ns_m, ns_v)` is a list with three entries indicating which |N3LO| variation should be used (if requested),
+/// where values `1` or `2` indicate the upper or lower bound respectively, while any other value returns the central (averaged) value.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD+1, MAX_ORDER_QED+1, 2, 2)`. The first
 /// `order_qcd + 1` entries along the QCD axis and `order_qed + 1` along the QED axis

--- a/crates/ekore/src/anomalous_dimensions/unpolarized/spacelike.rs
+++ b/crates/ekore/src/anomalous_dimensions/unpolarized/spacelike.rs
@@ -81,7 +81,7 @@ pub fn gamma_ns_qcd(
     gamma_ns
 }
 
-/// Compute the tower of the singlet anomalous dimension matrices.
+/// Compute the tower of the unpolarized, space-like singlet anomalous dimension matrices.
 ///
 /// `n3lo_variation = (gg, gq, qg, qq)` is a list indicating which variation should
 /// be used. `variation = 1,2` is the upper/lower bound, while any other value
@@ -91,7 +91,7 @@ pub fn gamma_ns_qcd(
 /// entries along the outer axis are filled; remaining slots are zero.
 pub fn gamma_singlet_qcd(
     order_qcd: usize,
-    c: &mut Cache,
+    cache: &mut Cache,
     nf: u8,
     n3lo_variation: [u8; 4],
 ) -> [[[Complex<f64>; 2]; 2]; MAX_ORDER_QCD] {
@@ -99,23 +99,23 @@ pub fn gamma_singlet_qcd(
         panic!("QCD beyond N3LO is not implemented");
     }
     let mut gamma_S = [[[Complex::<f64>::zero(); 2]; 2]; MAX_ORDER_QCD];
-    gamma_S[0] = as1::gamma_singlet(c, nf);
+    gamma_S[0] = as1::gamma_singlet(cache, nf);
     // NLO and beyond
     if order_qcd >= 2 {
-        gamma_S[1] = as2::gamma_singlet(c, nf);
+        gamma_S[1] = as2::gamma_singlet(cache, nf);
     }
     // NNLO and beyond
     if order_qcd >= 3 {
-        gamma_S[2] = as3::gamma_singlet(c, nf);
+        gamma_S[2] = as3::gamma_singlet(cache, nf);
     }
     // N3LO and beyond
     if order_qcd >= 4 {
-        gamma_S[3] = as4::gamma_singlet(c, nf, n3lo_variation);
+        gamma_S[3] = as4::gamma_singlet(cache, nf, n3lo_variation);
     }
     gamma_S
 }
 
-/// Compute the tower of the |QCD| x |QED| non-singlet anomalous dimensions.
+/// Compute the tower of the |QCD| x |QED| unpolarized, space-like non-singlet anomalous dimensions.
 ///
 /// `n3lo_variation = (ns_p, ns_m, ns_v)` is a list indicating which variation should
 /// be used. `variation = 1,2` is the upper/lower bound, while any other value
@@ -128,7 +128,7 @@ pub fn gamma_ns_qed(
     order_qcd: usize,
     order_qed: usize,
     mode: u16,
-    c: &mut Cache,
+    cache: &mut Cache,
     nf: u8,
     n3lo_variation: [u8; 3],
 ) -> [[Complex<f64>; MAX_ORDER_QED + 1]; MAX_ORDER_QCD + 1] {
@@ -146,37 +146,37 @@ pub fn gamma_ns_qed(
         PID_NSM_U | PID_NSM_D => PID_NSM,
         _ => mode,
     };
-    let gamma_qcd = gamma_ns_qcd(order_qcd, qcd_mode, c, nf, n3lo_variation);
+    let gamma_qcd = gamma_ns_qcd(order_qcd, qcd_mode, cache, nf, n3lo_variation);
     for j in 0..order_qcd {
         gamma_ns[1 + j][0] = gamma_qcd[j];
     }
     // QED corrections
     gamma_ns[0][1] = match mode {
-        PID_NSP_U | PID_NSM_U => EU2 * aem1::gamma_ns(c, nf),
-        PID_NSP_D | PID_NSM_D => ED2 * aem1::gamma_ns(c, nf),
+        PID_NSP_U | PID_NSM_U => EU2 * aem1::gamma_ns(cache, nf),
+        PID_NSP_D | PID_NSM_D => ED2 * aem1::gamma_ns(cache, nf),
         _ => panic!("Unknown non-singlet sector element"),
     };
     if order_qed >= 2 {
         gamma_ns[0][2] = match mode {
-            PID_NSP_U => EU2 * aem2::gamma_nspu(c, nf),
-            PID_NSP_D => ED2 * aem2::gamma_nspd(c, nf),
-            PID_NSM_U => EU2 * aem2::gamma_nsmu(c, nf),
-            PID_NSM_D => ED2 * aem2::gamma_nsmd(c, nf),
+            PID_NSP_U => EU2 * aem2::gamma_nspu(cache, nf),
+            PID_NSP_D => ED2 * aem2::gamma_nspd(cache, nf),
+            PID_NSM_U => EU2 * aem2::gamma_nsmu(cache, nf),
+            PID_NSM_D => ED2 * aem2::gamma_nsmd(cache, nf),
             _ => panic!("Unknown non-singlet sector element"),
         };
     }
     // QCDxQED corrections
     gamma_ns[1][1] = match mode {
-        PID_NSP_U => EU2 * as1aem1::gamma_nsp(c, nf),
-        PID_NSP_D => ED2 * as1aem1::gamma_nsp(c, nf),
-        PID_NSM_U => EU2 * as1aem1::gamma_nsm(c, nf),
-        PID_NSM_D => ED2 * as1aem1::gamma_nsm(c, nf),
+        PID_NSP_U => EU2 * as1aem1::gamma_nsp(cache, nf),
+        PID_NSP_D => ED2 * as1aem1::gamma_nsp(cache, nf),
+        PID_NSM_U => EU2 * as1aem1::gamma_nsm(cache, nf),
+        PID_NSM_D => ED2 * as1aem1::gamma_nsm(cache, nf),
         _ => panic!("Unknown non-singlet sector element"),
     };
     gamma_ns
 }
 
-/// Compute the tower of the |QCD| x |QED| singlet anomalous dimensions matrices.
+/// Compute the tower of the |QCD| x |QED| unpolarized, space-like singlet anomalous dimensions matrices.
 ///
 /// `n3lo_variation = (gg, gq, qg, qq, ns_p, ns_m, ns_v)` is a list indicating which variation should
 /// be used. `variation = 1,2` is the upper/lower bound, while any other value
@@ -188,7 +188,7 @@ pub fn gamma_ns_qed(
 pub fn gamma_singlet_qed(
     order_qcd: usize,
     order_qed: usize,
-    c: &mut Cache,
+    cache: &mut Cache,
     nf: u8,
     n3lo_variation: [u8; 7],
 ) -> [[[[Complex<f64>; 4]; 4]; MAX_ORDER_QED + 1]; MAX_ORDER_QCD + 1] {
@@ -201,11 +201,16 @@ pub fn gamma_singlet_qed(
     let mut gamma_s = [[[[Complex::<f64>::zero(); 4]; 4]; MAX_ORDER_QED + 1]; MAX_ORDER_QCD + 1];
 
     // QCD corrections
-    let gamma_qcd_s = gamma_singlet_qcd(order_qcd, c, nf, n3lo_variation[0..4].try_into().unwrap());
+    let gamma_qcd_s = gamma_singlet_qcd(
+        order_qcd,
+        cache,
+        nf,
+        n3lo_variation[0..4].try_into().unwrap(),
+    );
     let gamma_qcd_nsp = gamma_ns_qcd(
         order_qcd,
         PID_NSP,
-        c,
+        cache,
         nf,
         n3lo_variation[4..7].try_into().unwrap(),
     );
@@ -239,16 +244,16 @@ pub fn gamma_singlet_qed(
         ];
     }
     // QED corrections
-    gamma_s[0][1] = aem1::gamma_singlet(c, nf);
+    gamma_s[0][1] = aem1::gamma_singlet(cache, nf);
     if order_qed >= 2 {
-        gamma_s[0][2] = aem2::gamma_singlet(c, nf);
+        gamma_s[0][2] = aem2::gamma_singlet(cache, nf);
     }
     // QCDxQED corrections
-    gamma_s[1][1] = as1aem1::gamma_singlet(c, nf);
+    gamma_s[1][1] = as1aem1::gamma_singlet(cache, nf);
     gamma_s
 }
 
-/// Compute the tower of the |QCD| x |QED| valence anomalous dimensions matrices.
+/// Compute the tower of the |QCD| x |QED| unpolarized, space-like valence anomalous dimensions matrices.
 ///
 /// `n3lo_variation = (ns_p, ns_m, ns_v)` is a list indicating which variation should
 /// be used. `variation = 1,2` is the upper/lower bound, while any other value
@@ -260,7 +265,7 @@ pub fn gamma_singlet_qed(
 pub fn gamma_valence_qed(
     order_qcd: usize,
     order_qed: usize,
-    c: &mut Cache,
+    cache: &mut Cache,
     nf: u8,
     n3lo_variation: [u8; 3],
 ) -> [[[[Complex<f64>; 2]; 2]; MAX_ORDER_QED + 1]; MAX_ORDER_QCD + 1] {
@@ -273,8 +278,8 @@ pub fn gamma_valence_qed(
     let mut gamma_v = [[[[Complex::<f64>::zero(); 2]; 2]; MAX_ORDER_QED + 1]; MAX_ORDER_QCD + 1];
 
     // QCD corrections
-    let gamma_qcd_nsv = gamma_ns_qcd(order_qcd, PID_NSV, c, nf, n3lo_variation);
-    let gamma_qcd_nsm = gamma_ns_qcd(order_qcd, PID_NSM, c, nf, n3lo_variation);
+    let gamma_qcd_nsv = gamma_ns_qcd(order_qcd, PID_NSV, cache, nf, n3lo_variation);
+    let gamma_qcd_nsm = gamma_ns_qcd(order_qcd, PID_NSM, cache, nf, n3lo_variation);
     for j in 0..order_qcd {
         gamma_v[1 + j][0] = [
             [gamma_qcd_nsv[j], Complex::<f64>::zero()],
@@ -282,12 +287,12 @@ pub fn gamma_valence_qed(
         ];
     }
     // QED corrections
-    gamma_v[0][1] = aem1::gamma_valence(c, nf);
+    gamma_v[0][1] = aem1::gamma_valence(cache, nf);
     if order_qed >= 2 {
-        gamma_v[0][2] = aem2::gamma_valence(c, nf);
+        gamma_v[0][2] = aem2::gamma_valence(cache, nf);
     }
     // QCDxQED corrections
-    gamma_v[1][1] = as1aem1::gamma_valence(c, nf);
+    gamma_v[1][1] = as1aem1::gamma_valence(cache, nf);
     gamma_v
 }
 
@@ -303,18 +308,18 @@ mod tests {
     fn test_gamma_ns_qcd() {
         const NF: u8 = 3;
         const N: Complex<f64> = cmplx!(1., 0.);
-        let mut c = Cache::new(N);
+        let mut cache = Cache::new(N);
         let n3lo_variation: [u8; 3] = [0, 0, 0];
         assert_approx_eq_cmplx!(
             f64,
-            gamma_ns_qcd(3, PID_NSP, &mut c, NF, n3lo_variation)[0],
+            gamma_ns_qcd(3, PID_NSP, &mut cache, NF, n3lo_variation)[0],
             cmplx!(0., 0.),
             epsilon = 1e-14
         );
 
         assert_approx_eq_cmplx_1d!(
             f64,
-            gamma_ns_qcd(2, PID_NSM, &mut c, NF, n3lo_variation),
+            gamma_ns_qcd(2, PID_NSM, &mut cache, NF, n3lo_variation),
             [cmplx!(0., 0.); 2],
             2,
             epsilon = 2e-6
@@ -322,7 +327,7 @@ mod tests {
 
         assert_approx_eq_cmplx_1d!(
             f64,
-            gamma_ns_qcd(3, PID_NSM, &mut c, NF, n3lo_variation),
+            gamma_ns_qcd(3, PID_NSM, &mut cache, NF, n3lo_variation),
             [cmplx!(0., 0.); 3],
             3,
             epsilon = 2e-4
@@ -330,13 +335,13 @@ mod tests {
 
         assert_approx_eq_cmplx_1d!(
             f64,
-            gamma_ns_qcd(3, PID_NSV, &mut c, NF, n3lo_variation),
+            gamma_ns_qcd(3, PID_NSV, &mut cache, NF, n3lo_variation),
             [cmplx!(0., 0.); 3],
             3,
             epsilon = 8e-4
         );
 
-        let gamma_nsp = gamma_ns_qcd(4, PID_NSP, &mut c, NF, n3lo_variation);
+        let gamma_nsp = gamma_ns_qcd(4, PID_NSP, &mut cache, NF, n3lo_variation);
         assert!(gamma_nsp.iter().any(|x| x.norm() > 1e-6));
     }
 
@@ -345,8 +350,8 @@ mod tests {
     fn test_gamma_ns_qcd_order5_panics() {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(1.234, 0.);
-        let mut c = Cache::new(N);
-        gamma_ns_qcd(5, PID_NSP, &mut c, NF, [0u8; 3]);
+        let mut cache = Cache::new(N);
+        gamma_ns_qcd(5, PID_NSP, &mut cache, NF, [0u8; 3]);
     }
 
     #[test]
@@ -354,22 +359,22 @@ mod tests {
     fn test_gamma_singlet_qcd_order5_panics() {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(1.234, 0.);
-        let mut c = Cache::new(N);
-        gamma_singlet_qcd(5, &mut c, NF, [0u8; 4]);
+        let mut cache = Cache::new(N);
+        gamma_singlet_qcd(5, &mut cache, NF, [0u8; 4]);
     }
 
     #[test]
     fn test_gamma_ns_qed() {
         const NF: u8 = 3;
         const N: Complex<f64> = cmplx!(1., 0.);
-        let mut c = Cache::new(N);
+        let mut cache = Cache::new(N);
         let n3lo_variation: [u8; 3] = [0, 0, 0];
 
         // ns-
         for pid in [PID_NSM_U, PID_NSM_D] {
             assert_approx_eq_cmplx_2d!(
                 f64,
-                gamma_ns_qed(1, 1, pid, &mut c, NF, n3lo_variation),
+                gamma_ns_qed(1, 1, pid, &mut cache, NF, n3lo_variation),
                 [[cmplx!(0., 0.); 2]; 2],
                 2,
                 epsilon = 1e-5
@@ -381,12 +386,12 @@ mod tests {
             // as^0 a^0 must be trivial
             assert_approx_eq_cmplx!(
                 f64,
-                gamma_ns_qed(1, 1, pid, &mut c, NF, n3lo_variation)[0][0],
+                gamma_ns_qed(1, 1, pid, &mut cache, NF, n3lo_variation)[0][0],
                 cmplx!(0., 0.)
             );
             assert_approx_eq_cmplx!(
                 f64,
-                gamma_ns_qed(1, 1, pid, &mut c, NF, n3lo_variation)[0][1],
+                gamma_ns_qed(1, 1, pid, &mut cache, NF, n3lo_variation)[0][1],
                 cmplx!(0., 0.),
                 epsilon = 1e-5
             );
@@ -394,7 +399,7 @@ mod tests {
 
         // aem2 + as1aem1
         for pid in [PID_NSM_U, PID_NSM_D] {
-            let g = gamma_ns_qed(1, 2, pid, &mut c, NF, n3lo_variation);
+            let g = gamma_ns_qed(1, 2, pid, &mut cache, NF, n3lo_variation);
             for row in g.iter().take(2) {
                 assert_approx_eq_cmplx_1d!(f64, row, [cmplx!(0., 0.); 3], 3, epsilon = 1e-5);
             }
@@ -402,7 +407,7 @@ mod tests {
 
         // as2
         for pid in [PID_NSM_U, PID_NSM_D] {
-            let g = gamma_ns_qed(2, 1, pid, &mut c, NF, n3lo_variation);
+            let g = gamma_ns_qed(2, 1, pid, &mut cache, NF, n3lo_variation);
             for row in g.iter().take(3) {
                 assert_approx_eq_cmplx_1d!(f64, row, [cmplx!(0., 0.); 2], 2, epsilon = 1e-5);
             }
@@ -410,7 +415,7 @@ mod tests {
 
         // as3
         for pid in [PID_NSM_U, PID_NSM_D] {
-            let g = gamma_ns_qed(3, 1, pid, &mut c, NF, n3lo_variation);
+            let g = gamma_ns_qed(3, 1, pid, &mut cache, NF, n3lo_variation);
             for row in g.iter().take(4) {
                 assert_approx_eq_cmplx_1d!(f64, row, [cmplx!(0., 0.); 2], 2, epsilon = 1e-3);
             }
@@ -422,8 +427,8 @@ mod tests {
     fn test_gamma_ns_qed_qcd_order5_panics() {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(1.234, 0.);
-        let mut c = Cache::new(N);
-        gamma_ns_qed(5, 1, PID_NSP_U, &mut c, NF, [0u8; 3]);
+        let mut cache = Cache::new(N);
+        gamma_ns_qed(5, 1, PID_NSP_U, &mut cache, NF, [0u8; 3]);
     }
 
     #[test]
@@ -431,8 +436,8 @@ mod tests {
     fn test_gamma_ns_qed_qed_order3_panics() {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(1.234, 0.);
-        let mut c = Cache::new(N);
-        gamma_ns_qed(1, 3, PID_NSP_U, &mut c, NF, [0u8; 3]);
+        let mut cache = Cache::new(N);
+        gamma_ns_qed(1, 3, PID_NSP_U, &mut cache, NF, [0u8; 3]);
     }
 
     #[test]
@@ -440,19 +445,19 @@ mod tests {
     fn test_unknown_pid_panics() {
         const NF: u8 = 3;
         const N: Complex<f64> = cmplx!(2., 0.);
-        let mut c = Cache::new(N);
+        let mut cache = Cache::new(N);
         // PID 10106 is not a valid non-singlet mode
-        gamma_ns_qed(2, 0, 10106, &mut c, NF, [0u8; 3]);
+        gamma_ns_qed(2, 0, 10106, &mut cache, NF, [0u8; 3]);
     }
 
     #[test]
     fn test_gamma_valence_qed() {
         const NF: u8 = 3;
         const N: Complex<f64> = cmplx!(2., 0.);
-        let mut c = Cache::new(N);
+        let mut cache = Cache::new(N);
         let n3lo_variation: [u8; 3] = [0, 0, 0];
 
-        let g = gamma_valence_qed(3, 2, &mut c, NF, n3lo_variation);
+        let g = gamma_valence_qed(3, 2, &mut cache, NF, n3lo_variation);
         // as^0 a^0 must be trivial
         assert_approx_eq_cmplx_2d!(f64, g[0][0], [[cmplx!(0., 0.); 2]; 2], 2);
         // reference from Python side
@@ -473,8 +478,8 @@ mod tests {
     fn test_gamma_valence_qed_qcd_order5_panics() {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(1.234, 0.);
-        let mut c = Cache::new(N);
-        gamma_valence_qed(5, 1, &mut c, NF, [0u8; 3]);
+        let mut cache = Cache::new(N);
+        gamma_valence_qed(5, 1, &mut cache, NF, [0u8; 3]);
     }
 
     #[test]
@@ -482,17 +487,17 @@ mod tests {
     fn test_gamma_valence_qed_qed_order3_panics() {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(1.234, 0.);
-        let mut c = Cache::new(N);
-        gamma_valence_qed(1, 3, &mut c, NF, [0u8; 3]);
+        let mut cache = Cache::new(N);
+        gamma_valence_qed(1, 3, &mut cache, NF, [0u8; 3]);
     }
 
     #[test]
     fn test_gamma_singlet_qed() {
         const NF: u8 = 3;
         const N: Complex<f64> = cmplx!(2., 0.);
-        let mut c = Cache::new(N);
+        let mut cache = Cache::new(N);
         let n3lo_variation: [u8; 7] = [0, 0, 0, 0, 0, 0, 0];
-        let g = gamma_singlet_qed(3, 2, &mut c, NF, n3lo_variation);
+        let g = gamma_singlet_qed(3, 2, &mut cache, NF, n3lo_variation);
         // as^0 a^0 must be trivial
         assert_approx_eq_cmplx_2d!(f64, g[0][0], [[cmplx!(0., 0.); 4]; 4], 4);
 
@@ -536,8 +541,8 @@ mod tests {
     fn test_gamma_singlet_qed_qcd_order5_panics() {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(1.234, 0.);
-        let mut c = Cache::new(N);
-        gamma_singlet_qed(5, 1, &mut c, NF, [0u8; 7]);
+        let mut cache = Cache::new(N);
+        gamma_singlet_qed(5, 1, &mut cache, NF, [0u8; 7]);
     }
 
     #[test]
@@ -545,16 +550,16 @@ mod tests {
     fn test_gamma_singlet_qed_qed_order3_panics() {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(1.234, 0.);
-        let mut c = Cache::new(N);
-        gamma_singlet_qed(1, 3, &mut c, NF, [0u8; 7]);
+        let mut cache = Cache::new(N);
+        gamma_singlet_qed(1, 3, &mut cache, NF, [0u8; 7]);
     }
 
     #[test]
     fn test_dim_singlet() {
         const NF: u8 = 3;
         const N: Complex<f64> = cmplx!(2., 0.);
-        let mut c = Cache::new(N);
-        let g = gamma_singlet_qed(3, 2, &mut c, NF, [0u8; 7]);
+        let mut cache = Cache::new(N);
+        let g = gamma_singlet_qed(3, 2, &mut cache, NF, [0u8; 7]);
         assert_eq!(g.len(), MAX_ORDER_QCD + 1);
         assert_eq!(g[0].len(), MAX_ORDER_QED + 1);
         assert_eq!(g[0][0].len(), 4);
@@ -565,8 +570,8 @@ mod tests {
     fn test_dim_valence() {
         const NF: u8 = 3;
         const N: Complex<f64> = cmplx!(2., 0.);
-        let mut c = Cache::new(N);
-        let g = gamma_valence_qed(3, 2, &mut c, NF, [0u8; 3]);
+        let mut cache = Cache::new(N);
+        let g = gamma_valence_qed(3, 2, &mut cache, NF, [0u8; 3]);
         assert_eq!(g.len(), MAX_ORDER_QCD + 1);
         assert_eq!(g[0].len(), MAX_ORDER_QED + 1);
         assert_eq!(g[0][0].len(), 2);
@@ -577,11 +582,11 @@ mod tests {
     fn test_dim_nsp() {
         const NF: u8 = 3;
         const N: Complex<f64> = cmplx!(2., 0.);
-        let mut c = Cache::new(N);
-        let g = gamma_ns_qed(3, 2, PID_NSP_U, &mut c, NF, [0u8; 3]);
+        let mut cache = Cache::new(N);
+        let g = gamma_ns_qed(3, 2, PID_NSP_U, &mut cache, NF, [0u8; 3]);
         assert_eq!(g.len(), MAX_ORDER_QCD + 1);
         assert_eq!(g[0].len(), MAX_ORDER_QED + 1);
-        let g = gamma_ns_qed(3, 2, PID_NSP_D, &mut c, NF, [0u8; 3]);
+        let g = gamma_ns_qed(3, 2, PID_NSP_D, &mut cache, NF, [0u8; 3]);
         assert_eq!(g.len(), MAX_ORDER_QCD + 1);
         assert_eq!(g[0].len(), MAX_ORDER_QED + 1);
     }

--- a/crates/ekore/src/anomalous_dimensions/unpolarized/spacelike.rs
+++ b/crates/ekore/src/anomalous_dimensions/unpolarized/spacelike.rs
@@ -97,6 +97,10 @@ pub fn gamma_ns_qcd(
 /// - $a_S^4$ [\[Falcioni:2024qpd\]][crate::bib::Falcioni2024qpd] [\[Falcioni:2024xyt\]][crate::bib::Falcioni2024xyt]
 ///   [\[Falcioni:2023luc\]][crate::bib::Falcioni2023luc] [\[Falcioni:2023vqq\]][crate::bib::Falcioni2023vqq]
 ///   [\[Moch:2017uml\]][crate::bib::Moch2017uml]
+///
+/// # Panics
+///
+/// Panics if `order_qcd` is larger than the currently available order.
 pub fn gamma_singlet_qcd(
     order_qcd: usize,
     cache: &mut Cache,
@@ -138,6 +142,11 @@ pub fn gamma_singlet_qcd(
 /// - $a_{em}^1$ [\[Carrazza:2015dea\]][crate::bib::Carrazza2015dea]
 /// - $a_{em}^2$ [\[deFlorian:2016gvk\]][crate::bib::deFlorian2016gvk]
 /// - $a_s^1a_{em}^1$ [\[deFlorian:2015ujt\]][crate::bib::deFlorian2015ujt]
+///
+/// # Panics
+///
+/// Panics if `order_qcd` or `order_qed` is larger than the currently available order or `mode` is
+/// not a valid |PID|.
 pub fn gamma_ns_qed(
     order_qcd: usize,
     order_qed: usize,
@@ -211,6 +220,10 @@ pub fn gamma_ns_qed(
 /// - $a_S^4$ [\[Falcioni:2024qpd\]][crate::bib::Falcioni2024qpd] [\[Falcioni:2024xyt\]][crate::bib::Falcioni2024xyt]
 ///   [\[Falcioni:2023luc\]][crate::bib::Falcioni2023luc] [\[Falcioni:2023vqq\]][crate::bib::Falcioni2023vqq]
 ///   [\[Moch:2017uml\]][crate::bib::Moch2017uml]
+///
+/// # Panics
+///
+/// Panics if `order_qcd` or `order_qed` is larger than the currently available order.
 pub fn gamma_singlet_qed(
     order_qcd: usize,
     order_qed: usize,
@@ -298,6 +311,10 @@ pub fn gamma_singlet_qed(
 /// - $a_s^1a_{em}^1$ [\[deFlorian:2015ujt\]][crate::bib::deFlorian2015ujt]
 /// - $a_s^3$ [\[Moch:2004pa\]][crate::bib::Moch2004pa] [\[Vogt:2004mw\]](crate::bib::Vogt2004mw)
 /// - $a_S^4$ [\[Moch:2017uml\]][crate::bib::Moch2017uml]
+///
+/// # Panics
+///
+/// Panics if `order_qcd` or `order_qed` is larger than the currently available order.
 pub fn gamma_valence_qed(
     order_qcd: usize,
     order_qed: usize,

--- a/crates/ekore/src/harmonics/cache.rs
+++ b/crates/ekore/src/harmonics/cache.rs
@@ -81,7 +81,7 @@ const CACHE_SIZE: usize = 20;
 /// Hold all cached values.
 ///
 /// We use implementations from [\[Vogt:2004ns\]](crate::bib::Vogt2004ns) [\[KOLBIG1972221\]](crate::bib::KOLBIG1972221)
-/// [CERNlib](http://cernlib.web.cern.ch/cernlib/), name from [\[MuselliPhD\]](crate::bib::MuselliPhD)
+/// [CERNlib](http://cernlib.web.cern.ch/cernlib/)
 pub struct Cache {
     /// Mellin N
     n: Complex<f64>,

--- a/crates/ekore/src/harmonics/cache.rs
+++ b/crates/ekore/src/harmonics/cache.rs
@@ -79,6 +79,9 @@ impl K {
 const CACHE_SIZE: usize = 20;
 
 /// Hold all cached values.
+///
+/// We use implementations from [\[Vogt:2004ns\]](crate::bib::Vogt2004ns) [\[KOLBIG1972221\]](crate::bib::KOLBIG1972221)
+/// [CERNlib](http://cernlib.web.cern.ch/cernlib/), name from [\[MuselliPhD\]](crate::bib::MuselliPhD)
 pub struct Cache {
     /// Mellin N
     n: Complex<f64>,

--- a/crates/ekore/src/lib.rs
+++ b/crates/ekore/src/lib.rs
@@ -1,4 +1,24 @@
 //! Library for anomalous dimension in |DGLAP| and |OME|.
+//!
+//! # Introduction
+//!
+//! `ekore` is a library for evolving collinear distributions in perturbative |QCD| and part of the [EKO framework](https://eko.readthedocs.io>).
+//! In particular, it provides a common access to anomalous dimensions $\gamma$ and |OME| $\mathbf A$ needed for the evolution of |PDF| and similar objects.
+//! The targeted objects obey, first, |DGLAP| like differential equations,
+//! $$ \mu_F^2 \frac{d}{d\mu_F^2} \tilde{\mathbf{f}}(\mu_F^2) = -\gamma(a_s) \cdot \tilde{\mathbf{f}}(\mu_F^2) $$
+//! and, second, a matching procedure, when changing the number of active flavors,
+//! $$ \tilde{\mathbf{f}}^{(n_f+1)}(\mu^2)= {\mathbf{R}^{(n_f+1)}} \tilde{\mathbf{A}}^{(n_f+1)}(\mu^2, m^2) \tilde{\mathbf{f}}^{(n_f)}(\mu^2) \,, $$
+//! where $ {\mathbf{R}^{(n_f+1)}} $ performs the necessary flavor basis rotation.
+//!
+//! # Available functions
+//!
+//! We currently support:
+//! - unpolarized PDF: [anomalous dimensions][crate::anomalous_dimensions::unpolarized::spacelike], [operator matrix elements][crate::operator_matrix_elements::unpolarized::spacelike]
+//! - longitudinally polarized PDF: [anomalous dimensions][crate::anomalous_dimensions::polarized::spacelike]
+//!
+//! Please refer to the individual functions to see the currently implemented perturbative accuracies.
+//!
+//! Note that we only cite the work from which we have implemented the object and we refer to this publication for further relevant citations and/or the original source.
 
 // Let's stick to the original names which often come from FORTRAN, where such convention do not exists
 #![allow(non_snake_case)]

--- a/crates/ekore/src/operator_matrix_elements/unpolarized/spacelike.rs
+++ b/crates/ekore/src/operator_matrix_elements/unpolarized/spacelike.rs
@@ -9,8 +9,8 @@ mod as2;
 /// Compute the tower of the unpolarized, space-like singlet |OME|.
 ///
 /// This function computes the first `matching_order_qcd` entries at the Mellin variable set in `cache`
-/// using `nf` light flavors and `L`, logarithm of the squared ratio of factorization and renormalization
-/// scale $\ln(\mu_F^2 / m^2)$.
+/// using `nf` light flavors and `L`, logarithm of the squared ratio of factorization scale and mass
+/// $\ln(\mu_F^2 / m^2)$.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2, 3, 3)`. Only the first `matching_order_qcd`
 /// entries along the outer axis are filled; remaining slots are zero.
@@ -46,8 +46,8 @@ pub fn A_singlet(
 /// Compute the tower of the unpolarized, space-like non-singlet |OME|.
 ///
 /// This function computes the first `matching_order_qcd` entries at the Mellin variable set in `cache`
-/// using `nf` light flavors and `L`, logarithm of the squared ratio of factorization and renormalization
-/// scale $\ln(\mu_F^2 / m^2)$.
+/// using `nf` light flavors and `L`, logarithm of the squared ratio of factorization scale and mass
+/// $\ln(\mu_F^2 / m^2)$.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2, 2, 2)`. Only the first `matching_order_qcd`
 /// entries along the outer axis are filled; remaining slots are zero.

--- a/crates/ekore/src/operator_matrix_elements/unpolarized/spacelike.rs
+++ b/crates/ekore/src/operator_matrix_elements/unpolarized/spacelike.rs
@@ -1,4 +1,4 @@
-//! The unpolarized, space-like |OME| at various couplings power.
+//! The unpolarized, space-like |OME|.
 use crate::constants::MAX_ORDER_QCD;
 use crate::harmonics::cache::Cache;
 use num::Zero;
@@ -6,13 +6,13 @@ use num::complex::Complex;
 mod as1;
 mod as2;
 
-/// Compute the tower of the singlet |OME|.
+/// Compute the tower of the unpolarized, space-like singlet |OME|.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2, 3, 3)`. Only the first `matching_order_qcd`
 /// entries along the outer axis are filled; remaining slots are zero.
 pub fn A_singlet(
     matching_order_qcd: usize,
-    c: &mut Cache,
+    cache: &mut Cache,
     nf: u8,
     L: f64,
 ) -> [[[Complex<f64>; 3]; 3]; MAX_ORDER_QCD - 2] {
@@ -21,22 +21,22 @@ pub fn A_singlet(
     }
     let mut A_s = [[[Complex::<f64>::zero(); 3]; 3]; MAX_ORDER_QCD - 2];
     if matching_order_qcd >= 1 {
-        A_s[0] = as1::A_singlet(c, nf, L);
+        A_s[0] = as1::A_singlet(cache, nf, L);
     }
     if matching_order_qcd >= 2 {
         // TODO recover MSbar mass
-        A_s[1] = as2::A_singlet(c, nf, L, false);
+        A_s[1] = as2::A_singlet(cache, nf, L, false);
     }
     A_s
 }
 
-/// Compute the tower of the non-singlet |OME|.
+/// Compute the tower of the unpolarized, space-like non-singlet |OME|.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2, 2, 2)`. Only the first `matching_order_qcd`
 /// entries along the outer axis are filled; remaining slots are zero.
 pub fn A_non_singlet(
     matching_order_qcd: usize,
-    c: &mut Cache,
+    cache: &mut Cache,
     nf: u8,
     L: f64,
 ) -> [[[Complex<f64>; 2]; 2]; MAX_ORDER_QCD - 2] {
@@ -45,10 +45,10 @@ pub fn A_non_singlet(
     }
     let mut A_ns = [[[Complex::<f64>::zero(); 2]; 2]; MAX_ORDER_QCD - 2];
     if matching_order_qcd >= 1 {
-        A_ns[0] = as1::A_ns(c, nf, L);
+        A_ns[0] = as1::A_ns(cache, nf, L);
     }
     if matching_order_qcd >= 2 {
-        A_ns[1] = as2::A_ns(c, nf, L);
+        A_ns[1] = as2::A_ns(cache, nf, L);
     }
     A_ns
 }
@@ -65,8 +65,8 @@ mod tests {
         const N: Complex<f64> = cmplx!(0., 1.);
         const L: f64 = 0.0;
         for matching_order_qcd in 1..=2usize {
-            let mut c = Cache::new(N);
-            let a_s = A_singlet(matching_order_qcd, &mut c, NF, L);
+            let mut cache = Cache::new(N);
+            let a_s = A_singlet(matching_order_qcd, &mut cache, NF, L);
             assert_eq!(a_s.len(), MAX_ORDER_QCD - 2);
             assert_eq!(a_s[0].len(), 3);
             assert_eq!(a_s[0][0].len(), 3);
@@ -74,7 +74,7 @@ mod tests {
             for item in a_s.iter().skip(matching_order_qcd) {
                 assert_approx_eq_cmplx_2d!(f64, item, [[cmplx!(0., 0.); 3]; 3], 3);
             }
-            let a_ns = A_non_singlet(matching_order_qcd, &mut c, NF, L);
+            let a_ns = A_non_singlet(matching_order_qcd, &mut cache, NF, L);
             assert_eq!(a_ns.len(), MAX_ORDER_QCD - 2);
             assert_eq!(a_ns[0].len(), 2);
             assert_eq!(a_ns[0][0].len(), 2);
@@ -91,8 +91,8 @@ mod tests {
         const NF: u8 = 5;
         const N: Complex<f64> = cmplx!(1., 0.);
         const L: f64 = 0.0;
-        let mut c = Cache::new(N);
-        let a_ns = A_non_singlet(2, &mut c, NF, L);
+        let mut cache = Cache::new(N);
+        let a_ns = A_non_singlet(2, &mut cache, NF, L);
         // LO
         assert_approx_eq_cmplx_2d!(f64, a_ns[0], [[cmplx!(0., 0.); 2]; 2], 2, epsilon = 1e-14);
         // NNLO
@@ -105,8 +105,8 @@ mod tests {
         const NF: u8 = 5;
         const N: Complex<f64> = cmplx!(2., 0.);
         const L: f64 = 100.;
-        let mut c = Cache::new(N);
-        let a_s = A_singlet(2, &mut c, NF, L);
+        let mut cache = Cache::new(N);
+        let a_s = A_singlet(2, &mut cache, NF, L);
         // LO
         assert_approx_eq_cmplx!(
             f64,
@@ -140,8 +140,8 @@ mod tests {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(1.234, 0.);
         const L: f64 = 0.0;
-        let mut c = Cache::new(N);
-        A_singlet(3, &mut c, NF, L);
+        let mut cache = Cache::new(N);
+        A_singlet(3, &mut cache, NF, L);
     }
 
     #[test]
@@ -150,7 +150,7 @@ mod tests {
         const NF: u8 = 4;
         const N: Complex<f64> = cmplx!(1.234, 0.);
         const L: f64 = 0.0;
-        let mut c = Cache::new(N);
-        A_non_singlet(3, &mut c, NF, L);
+        let mut cache = Cache::new(N);
+        A_non_singlet(3, &mut cache, NF, L);
     }
 }

--- a/crates/ekore/src/operator_matrix_elements/unpolarized/spacelike.rs
+++ b/crates/ekore/src/operator_matrix_elements/unpolarized/spacelike.rs
@@ -15,6 +15,10 @@ mod as2;
 ///
 /// - $a_s^1$ [\[Ball:2015tna\]](crate::bib::Ball2015tna) [\[Buza:1996wv\]](crate::bib::Buza1996wv)
 /// - $a_s^2$ [\[Buza:1996wv\]](crate::bib::Buza1996wv) [\[Bierenbaum:2009zt\]](crate::bib::Bierenbaum2009zt)
+///
+/// # Panics
+///
+/// Panics if `matching_order_qcd` is larger than the currently available order.
 pub fn A_singlet(
     matching_order_qcd: usize,
     cache: &mut Cache,
@@ -44,6 +48,10 @@ pub fn A_singlet(
 ///
 /// - $a_s^1$ [\[Ball:2015tna\]](crate::bib::Ball2015tna)
 /// - $a_s^2$ [\[Buza:1996wv\]](crate::bib::Buza1996wv)
+///
+/// # Panics
+///
+/// Panics if `matching_order_qcd` is larger than the currently available order.
 pub fn A_non_singlet(
     matching_order_qcd: usize,
     cache: &mut Cache,

--- a/crates/ekore/src/operator_matrix_elements/unpolarized/spacelike.rs
+++ b/crates/ekore/src/operator_matrix_elements/unpolarized/spacelike.rs
@@ -10,6 +10,11 @@ mod as2;
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2, 3, 3)`. Only the first `matching_order_qcd`
 /// entries along the outer axis are filled; remaining slots are zero.
+///
+/// # Available perturbative orders:
+///
+/// - $a_s^1$ [\[Ball:2015tna\]](crate::bib::Ball2015tna) [\[Buza:1996wv\]](crate::bib::Buza1996wv)
+/// - $a_s^2$ [\[Buza:1996wv\]](crate::bib::Buza1996wv) [\[Bierenbaum:2009zt\]](crate::bib::Bierenbaum2009zt)
 pub fn A_singlet(
     matching_order_qcd: usize,
     cache: &mut Cache,
@@ -34,6 +39,11 @@ pub fn A_singlet(
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2, 2, 2)`. Only the first `matching_order_qcd`
 /// entries along the outer axis are filled; remaining slots are zero.
+///
+/// # Available perturbative orders:
+///
+/// - $a_s^1$ [\[Ball:2015tna\]](crate::bib::Ball2015tna)
+/// - $a_s^2$ [\[Buza:1996wv\]](crate::bib::Buza1996wv)
 pub fn A_non_singlet(
     matching_order_qcd: usize,
     cache: &mut Cache,

--- a/crates/ekore/src/operator_matrix_elements/unpolarized/spacelike.rs
+++ b/crates/ekore/src/operator_matrix_elements/unpolarized/spacelike.rs
@@ -8,6 +8,10 @@ mod as2;
 
 /// Compute the tower of the unpolarized, space-like singlet |OME|.
 ///
+/// This function computes the first `matching_order_qcd` entries at the Mellin variable set in `cache`
+/// using `nf` light flavors and `L`, logarithm of the squared ratio of factorization and renormalization
+/// scale $\ln(\mu_F^2 / m^2)$.
+///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2, 3, 3)`. Only the first `matching_order_qcd`
 /// entries along the outer axis are filled; remaining slots are zero.
 ///
@@ -40,6 +44,10 @@ pub fn A_singlet(
 }
 
 /// Compute the tower of the unpolarized, space-like non-singlet |OME|.
+///
+/// This function computes the first `matching_order_qcd` entries at the Mellin variable set in `cache`
+/// using `nf` light flavors and `L`, logarithm of the squared ratio of factorization and renormalization
+/// scale $\ln(\mu_F^2 / m^2)$.
 ///
 /// Returns an array of shape `(MAX_ORDER_QCD - 2, 2, 2)`. Only the first `matching_order_qcd`
 /// entries along the outer axis are filled; remaining slots are zero.


### PR DESCRIPTION
As a side effect of #543 we do no longer expose the references for our implementations. However, since we rely 100% on external sources we must do so.