### PR TITLE
Fix Rust Releases

### DIFF
--- a/.github/workflows/unittests-capi.yml
+++ b/.github/workflows/unittests-capi.yml
@@ -4,7 +4,11 @@ on: push
 
 jobs:
   test-capi:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/.github/workflows/unittests-rust.yml
+++ b/.github/workflows/unittests-rust.yml
@@ -4,7 +4,11 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Get test data

--- a/.github/workflows/unittests-rust.yml
+++ b/.github/workflows/unittests-rust.yml
@@ -30,8 +30,12 @@ jobs:
       - name: Run clippy
         run: |
           poe clippy
-      - name: Install gsl
-        run: sudo apt-get install libgsl0-dev
+      - name: Install gsl (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libgsl0-dev
+      - name: Install gsl (macOS)
+        if: runner.os == 'macOS'
+        run: brew install gsl
       - name: Run Rust unit tests
         run: |
           poe rtest

--- a/crates/doc-header.html
+++ b/crates/doc-header.html
@@ -61,5 +61,7 @@
         for (let el of longs) replaceAbbrev(el);
         let shorts = document.getElementsByClassName("docblock-short");
         for (let el of shorts) replaceAbbrev(el);
+        let tables = document.getElementsByClassName("item-table");
+        for (let el of tables) replaceAbbrev(el);
     });
 </script>

--- a/crates/eko/pyproject.toml
+++ b/crates/eko/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "eko-rs"
-version = "0.0.0"
+dynamic = ["version"]
 requires-python = ">=3.11"
 classifiers = [
   "Programming Language :: Rust",

--- a/crates/ekore_capi/Cargo.toml
+++ b/crates/ekore_capi/Cargo.toml
@@ -17,7 +17,7 @@ exclude = ["tests"]
 rustdoc-args = ["--html-in-header", "doc-header.html"]
 
 [lib]
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["cdylib"]
 
 [features]
 capi = []

--- a/crates/ekore_capi/tests/run_tests.sh
+++ b/crates/ekore_capi/tests/run_tests.sh
@@ -33,6 +33,11 @@ run_section() {
         echo "  Compiling $name.$ext..."
         "$compiler" "$src" "${extra[@]}" \
             -L"$LIB_DIR" -lekore_capi -o "$bin" -Wl,-rpath,"$RPATH"
+
+        # macOS: cargo-c bakes an absolute /lib/... install name; fix it to @rpath
+        [ "$(uname)" = "Darwin" ] && install_name_tool -change \
+            "/lib/libekore_capi.0.0.1.dylib" "@rpath/libekore_capi.0.0.1.dylib" "$bin" 2>/dev/null || true
+
         echo "  Running $name..."
         "$bin"
         rm -f "$bin"

--- a/crates/ekore_capi/tests/run_tests.sh
+++ b/crates/ekore_capi/tests/run_tests.sh
@@ -35,8 +35,10 @@ run_section() {
             -L"$LIB_DIR" -lekore_capi -o "$bin" -Wl,-rpath,"$RPATH"
 
         # macOS: cargo-c bakes an absolute /lib/... install name; fix it to @rpath
-        [ "$(uname)" = "Darwin" ] && install_name_tool -change \
-            "/lib/libekore_capi.0.0.1.dylib" "@rpath/libekore_capi.0.0.1.dylib" "$bin" 2>/dev/null || true
+        if [ "$(uname)" = "Darwin" ]; then
+            old="$(otool -L "$bin" | awk '/\/lib\/libekore_capi/{print $1; exit}')"
+            [ -n "$old" ] && install_name_tool -change "$old" "@rpath/$(basename "$old")" "$bin"
+        fi
 
         echo "  Running $name..."
         "$bin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ rtest = "cargo test --workspace"
 fmtcheck = "cargo fmt --all -- --check"
 clippy = "cargo clippy --no-deps"
 rbib = { "shell" = "python crates/make_bib.py > crates/ekore/src/bib.rs" }
-build-capi = "cargo cinstall --release -p ekore_capi --destdir=./crates/ekore_capi/dist --prefix=/ --libdir=/lib --includedir=/include"
+build-capi = "cargo cinstall --release --library-type cdylib -p ekore_capi --destdir=./crates/ekore_capi/dist --prefix=/ --libdir=/lib --includedir=/include"
 ctest = "./crates/ekore_capi/tests/run_tests.sh"
 
 [tool.pytest.ini_options]

--- a/tests/data/assets.sh
+++ b/tests/data/assets.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 # This script downloads the test assets to run both Rust and Python unit tests.
 # The script is to be executed in the root directory of the repository.
 


### PR DESCRIPTION
Closes #555

In this PR we,
- Fix MacOS linking errors.
- Remove `staticlib` generation.
- Make `eko` versioning dynamic, hence changing the `.whl` name.