### PR TITLE
Fix/536 tutorial path

### DIFF
--- a/doc/source/overview/tutorials/output.ipynb
+++ b/doc/source/overview/tutorials/output.ipynb
@@ -19,14 +19,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "51dbf608-ccfb-4fb5-aca3-723a5f280f65",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "import eko"
+    "from pathlib import Path\n",
+    "\n",
+    "import eko\n",
+    "\n",
+    "path = Path(\"./myeko.tar\")"
    ]
   },
   {
@@ -39,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "daae3811-e7a6-4a7c-9f55-eef8ea1564b8",
    "metadata": {
     "tags": []
@@ -54,7 +58,7 @@
     }
    ],
    "source": [
-    "with eko.EKO.read(\"./myeko.tar\") as evolution_operator:\n",
+    "with eko.EKO.read(path) as evolution_operator:\n",
     "    print(type(evolution_operator))"
    ]
   },
@@ -68,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "e5c5b8af-d478-48ca-bb61-9a0de680252a",
    "metadata": {},
    "outputs": [
@@ -82,7 +86,7 @@
     }
    ],
    "source": [
-    "with eko.EKO.read(\"./myeko.tar\") as evolution_operator:\n",
+    "with eko.EKO.read(path) as evolution_operator:\n",
     "    # obtain theory card\n",
     "    print(evolution_operator.theory_card)\n",
     "    # or operator card\n",
@@ -100,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "c82e6733-946f-4210-a6fa-95f995ee5be5",
    "metadata": {},
    "outputs": [
@@ -113,7 +117,7 @@
     }
    ],
    "source": [
-    "with eko.EKO.read(\"./myeko.tar\") as evolution_operator:\n",
+    "with eko.EKO.read(path) as evolution_operator:\n",
     "    print(evolution_operator.evolgrid)"
    ]
   },
@@ -128,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "15262aee-1cfa-40f3-b072-b53ec5517784",
    "metadata": {},
    "outputs": [
@@ -142,7 +146,7 @@
     }
    ],
    "source": [
-    "with eko.EKO.read(\"./myeko.tar\") as evolution_operator:\n",
+    "with eko.EKO.read(path) as evolution_operator:\n",
     "    with evolution_operator.operator((10000.0, 5)) as op:\n",
     "        print(f\"operator: {op.operator.shape}\")\n",
     "        print(f\"error: {op.error.shape}\")"

--- a/doc/source/overview/tutorials/output.ipynb
+++ b/doc/source/overview/tutorials/output.ipynb
@@ -177,9 +177,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "eko-KkPVjVhh-py3.10",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "eko-kkpvjvhh-py3.10"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -191,7 +191,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/doc/source/overview/tutorials/pdf.ipynb
+++ b/doc/source/overview/tutorials/pdf.ipynb
@@ -68,14 +68,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "e110fe95-7f57-4b09-a224-ab66da5d7d64",
    "metadata": {},
    "outputs": [],
    "source": [
     "from ekobox.apply import apply_pdf\n",
     "\n",
-    "with eko.EKO.read(\"./myeko.tar\") as evolution_operator:\n",
+    "with eko.EKO.read(pathlib.Path(\"./myeko.tar\")) as evolution_operator:\n",
     "    evolved_pdfs, _integration_errors = apply_pdf(evolution_operator, pdf)"
    ]
   },

--- a/src/eko/io/struct.py
+++ b/src/eko/io/struct.py
@@ -387,7 +387,7 @@ class EKO:
         already extracted folder.
         """
         if isinstance(path, str):
-            path = Path(path)   
+            path = Path(path)
         # Take the absolute path in case we need to modify the eko in-place
         path = path.resolve()
         if extract:

--- a/src/eko/io/struct.py
+++ b/src/eko/io/struct.py
@@ -8,7 +8,7 @@ import tarfile
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import numpy as np
 import yaml
@@ -375,7 +375,7 @@ class EKO:
     @classmethod
     def read(
         cls,
-        path: Path,
+        path: Union[str, Path],
         extract: bool = True,
         dest: Optional[Path] = None,
         readonly: bool = True,
@@ -386,6 +386,8 @@ class EKO:
         format. Otherwise, the `path` is interpreted as the location of an
         already extracted folder.
         """
+        if isinstance(path, str):
+            path = Path(path)   
         # Take the absolute path in case we need to modify the eko in-place
         path = path.resolve()
         if extract:

--- a/tests/eko/io/test_struct.py
+++ b/tests/eko/io/test_struct.py
@@ -7,7 +7,6 @@ import pytest
 import yaml
 from packaging.version import parse
 
-import eko
 from eko import EKO, interpolation
 from eko.io import struct
 from eko.io.items import Target
@@ -216,16 +215,3 @@ class TestEKO:
             and version.micro == 0
             and version.is_postrelease
         )
-    def test_read_path(self, tmp_path):
-        """Test that read can accept both str and Path for the path argument."""
-        from ekobox.cards import example
-
-        path = tmp_path / "myeko.tar"
-        eko.solve(example.theory(), example.operator(), path)
-
-        #str path
-        with EKO.read(str(path)) as eko_str:
-            assert isinstance(eko_str, EKO)
-        #Path path
-        with EKO.read(path) as eko_path:
-            assert isinstance(eko_path, EKO)

--- a/tests/eko/io/test_struct.py
+++ b/tests/eko/io/test_struct.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 from packaging.version import parse
 
+import eko
 from eko import EKO, interpolation
 from eko.io import struct
 from eko.io.items import Target
@@ -215,3 +216,16 @@ class TestEKO:
             and version.micro == 0
             and version.is_postrelease
         )
+    def test_read_path(self, tmp_path):
+        """Test that read can accept both str and Path for the path argument."""
+        from ekobox.cards import example
+
+        path = tmp_path / "myeko.tar"
+        eko.solve(example.theory(), example.operator(), path)
+
+        #str path
+        with EKO.read(str(path)) as eko_str:
+            assert isinstance(eko_str, EKO)
+        #Path path
+        with EKO.read(path) as eko_path:
+            assert isinstance(eko_path, EKO)

--- a/tests/eko/runner/test_managed.py
+++ b/tests/eko/runner/test_managed.py
@@ -15,6 +15,9 @@ def test_raw(theory_card, operator_card, tmp_path):
     solve(tc, oc, path=path)
     with EKO.read(path) as eko_:
         check_shapes(eko_, eko_.xgrid, eko_.xgrid, tc, oc)
+    # EKO.read(path) should also accept a string path
+    with EKO.read(str(path)) as eko_str:
+        assert isinstance(eko_str, EKO)
 
 
 def test_vfns(theory_ffns, operator_card, tmp_path):


### PR DESCRIPTION
Closes #536 

Before you review my PR ,I wanted to let you know that i committed twice because i accidently committed the docker file in **342bef6** and **98b5d45** is the latest commit cleaning my mistake.
As for the research what i find is that #449 tightened the type handling - previously a str was passing silently. so option (a) is the best approach rather than using 'EKO.read' this helps keep consistent with #449 and also matches with other tutorials (eg dglap.ipynb).
Please let me know  if any changes are required. 
