### PR TITLE
Bug in as1aem1 splitting kernel + minor things

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Items without prefix refer to a global change.
 
 ## [Unreleased](https://github.com/NNPDF/eko/compare/v0.15.5...HEAD)
 
+### Fixed
+- Fix bug in ad.u.s.as1aem1. Thank you Giovanni Stagnitto (@gstagnit). ([#558](https://github.com/NNPDF/eko/pull/558))
+
 ## [0.15.5](https://github.com/NNPDF/eko/compare/v0.15.4...v0.15.5) - 2026-07-22
 
 ### Added

--- a/crates/ekore/src/anomalous_dimensions/unpolarized/spacelike/as1aem1.rs
+++ b/crates/ekore/src/anomalous_dimensions/unpolarized/spacelike/as1aem1.rs
@@ -2,7 +2,7 @@
 use crate::cmplx;
 use num::complex::Complex;
 
-use crate::constants::{CA, CF, ChargeCombinations, ED2, EU2, NC, TR, ZETA2, ZETA3};
+use crate::constants::{CA, CF, ChargeCombinations, ED2, EU2, TR, ZETA2, ZETA3};
 use crate::harmonics::cache::{Cache, K, recursive_harmonic_sum};
 use std::f64::consts::PI;
 
@@ -78,14 +78,14 @@ pub(super) fn gamma_gph(c: &mut Cache, _nf: u8) -> Complex<f64> {
 ///
 /// Implements Eq. (30) of [\[deFlorian:2015ujt\]][crate::bib::deFlorian2015ujt].
 pub(super) fn gamma_phg(c: &mut Cache, nf: u8) -> Complex<f64> {
-    TR / CF / CA * (NC as f64) * gamma_gph(c, nf)
+    TR / CF / CA * gamma_gph(c, nf)
 }
 
 /// Compute the quark-gluon singlet anomalous dimension.
 ///
 /// Implements Eq. (29) of [\[deFlorian:2015ujt\]][crate::bib::deFlorian2015ujt].
 pub(super) fn gamma_qg(c: &mut Cache, nf: u8) -> Complex<f64> {
-    TR / CF / CA * (NC as f64) * gamma_qph(c, nf)
+    TR / CF / CA * gamma_qph(c, nf)
 }
 
 /// Compute the gluon-quark singlet anomalous dimension.
@@ -110,7 +110,7 @@ pub(super) fn gamma_phph(_c: &mut Cache, nf: u8) -> Complex<f64> {
 ///
 /// Implements Eq. (31) of [\[deFlorian:2015ujt\]][crate::bib::deFlorian2015ujt].
 pub(super) fn gamma_gg(_c: &mut Cache, _nf: u8) -> Complex<f64> {
-    cmplx!(4.0 * TR * (NC as f64), 0.)
+    cmplx!(4.0 * TR, 0.)
 }
 
 /// Shift for $g_3(N)$ by 2.

--- a/doc/source/overview/tutorials/pdf.ipynb
+++ b/doc/source/overview/tutorials/pdf.ipynb
@@ -205,7 +205,7 @@
     "op_card.xgrid = eko.interpolation.XGrid([1e-3, 1e-2, 1e-1, 5e-1, 1.0])\n",
     "op_card.mugrid = [(10.0, 5), (100.0, 5)]\n",
     "# set QCD LO evolution\n",
-    "th_card.orders = (1, 0)"
+    "th_card.order = (1, 0)"
    ]
   },
   {
@@ -362,7 +362,7 @@
     "\n",
     "# setup the theory card - this can be mostly inferred from the PDF's .info file\n",
     "th_card = example.theory()\n",
-    "th_card.orders = (1, 0)  # QCD LO\n",
+    "th_card.order = (1, 0)  # QCD LO\n",
     "th_card.heavy.masses = HeavyQuarks(\n",
     "    [QuarkMassRef([1.3, nan]), QuarkMassRef([4.75, nan]), QuarkMassRef([172.0, nan])]\n",
     ")  # quark mass\n",

--- a/src/eko/kernels/singlet.py
+++ b/src/eko/kernels/singlet.py
@@ -290,7 +290,7 @@ def n3lo_decompose_expanded(gamma_singlet, a1, a0, nf):
         beta.b_qcd((4, 0), nf),
         beta.b_qcd((5, 0), nf),
     ]
-    j12 = ei.j12(a1, a0, nf)
+    j12 = ei.j12(a1, a0, beta0)
     j13 = as4_ei.j13_expanded(a1, a0, beta0, b_list)
     j23 = as4_ei.j23_expanded(a1, a0, beta0, b_list)
     j33 = as4_ei.j33_expanded(a1, a0, beta0)

--- a/src/ekore/anomalous_dimensions/unpolarized/space_like/as1aem1.py
+++ b/src/ekore/anomalous_dimensions/unpolarized/space_like/as1aem1.py
@@ -147,7 +147,7 @@ def gamma_phg(N):
     complex
         :math:`O(a_s^1a_{em}^1)` photon-gluon anomalous dimension :math:`\\gamma_{\\gamma g}^{(1,1)}(N)`
     """
-    return constants.TR / constants.CF / constants.CA * constants.NC * gamma_gph(N)
+    return constants.TR / constants.CF / constants.CA * gamma_gph(N)
 
 
 @nb.njit(cache=True)
@@ -173,13 +173,7 @@ def gamma_qg(N, nf, cache):
         :math:`O(a_s^1a_{em}^1)` quark-gluon singlet anomalous dimension
         :math:`\\gamma_{qg}^{(1,1)}(N)`
     """
-    return (
-        constants.TR
-        / constants.CF
-        / constants.CA
-        * constants.NC
-        * gamma_qph(N, nf, cache)
-    )
+    return constants.TR / constants.CF / constants.CA * gamma_qph(N, nf, cache)
 
 
 @nb.njit(cache=True)
@@ -241,7 +235,7 @@ def gamma_gg():
         :math:`O(a_s^1a_{em}^1)` gluon-gluon singlet anomalous dimension
         :math:`\\gamma_{gg}^{(1,1)}(N)`
     """
-    return 4.0 * constants.TR * constants.NC
+    return 4.0 * constants.TR
 
 
 @nb.njit(cache=True)


### PR DESCRIPTION
While debugging EKO evolution against my development version of eMELA, I realised that in the gluon-initiated mixed QED-QCD splitting kernels there is an additional factor of NC, that according to eq.(29)-(31) of 1512.00612 I think should not be there. By removing it, I find closer agreement to my numbers. Then I also fixed a typo in one tutorial notebook and I think that the argument of j12 in n3lo_decompose_expanded should be beta0 and not nf.