### PR TITLE
Update `architecture.md` with libome

### DIFF
--- a/extras/architecture.md
+++ b/extras/architecture.md
@@ -246,6 +246,16 @@ This internal crate exports C function pointers (such as `rust_quad_ker`) that `
 
 ---
 
+### 6.5 External C++ `libome` Integration for $\mathcal{O}(\alpha_s^3)$ OMEs (`extern-libome`)
+
+Operator matrix elements (OMEs) in `ekore` currently implement analytical Mellin $N$-space formulas up to $\mathcal{O}(\alpha_s^2)$ (`as2`). For the $\mathcal{O}(\alpha_s^3)$ (`as3`) corrections, work was initiated to allow the `ekore` crate to evaluate operator matrix elements using an external C++ library.
+
+However, direct integration is currently not possible because the underlying [libome](https://gitlab.com/libome/libome) library evaluates OMEs in Bjorken $x$-space rather than Mellin $N$-space.
+
+Pull Request [#562](https://github.com/NNPDF/eko/pull/562) was originally opened for the `extern-libome` branch to prototype C++ FFI bindings and build machinery, but was closed without deleting the branch. In the future, once Mellin $N$-space support is addressed, changes will be made on the `extern-libome` branch and a separate PR will be opened.
+
+---
+
 ## 7. Linear algebra and interpolation
 
 ### 7.1 Linear algebra for the singlet evolution solution

--- a/extras/architecture.md
+++ b/extras/architecture.md
@@ -174,7 +174,7 @@ To make `ekore` accessible across various ecosystems and languages without reimp
 
 - **`eko-rs` (`ekors`):** The internal bridge connecting Python EKO to `ekore` during operator integration (`rust_quad_ker`).
 - **`ekore_capi`:** Exposes `ekore` via a C-compatible ABI for C, C++, and Fortran callers.
-- **`ekore_rs` (`ekore-rs`):** Exposes `ekore` directly to Python using PyO3 bindings.
+- **`ekore-rs` (`ekore_rs`):** Exposes `ekore` directly to Python using PyO3 bindings.
 
 ---
 
@@ -221,7 +221,7 @@ This internal crate exports C function pointers (such as `rust_quad_ker`) that `
 
 ---
 
-### 6.3 ekore_rs (Python Bindings via PyO3)
+### 6.3 ekore-rs (Python Bindings via PyO3)
 
 **Directory:** `crates/ekore_py` (packaged as `ekore-rs` on PyPI, imported as `ekore_rs`)
 
@@ -242,7 +242,7 @@ This internal crate exports C function pointers (such as `rust_quad_ker`) that `
 | `ekore` | `crates/ekore` | Pure Rust | Native Rust API |
 | `eko-rs` (`ekors`) | `crates/eko` | Python (`eko` evolution runner) | Internal C FFI / `LowLevelCallable` bridge |
 | `ekore_capi` | `crates/ekore_capi` | C, C++, Fortran, FFI consumers | C ABI (`extern "C"`, `cbindgen`, `cargo-c`) |
-| `ekore_rs` (`ekore-rs`) | `crates/ekore_py` | Python (standalone physics API) | PyO3 / Maturin extension module |
+| `ekore-rs` (`ekore_rs`) | `crates/ekore_py` | Python (standalone physics API) | PyO3 / Maturin extension module |
 
 ---
 


### PR DESCRIPTION
In this PR, we update the `architecture.md` file with information about the library `libome` and the branch `extern-libome`, as mentioned [here](https://github.com/NNPDF/eko/pull/562#issuecomment-5541014332).