### PR TITLE
Pass plain ints instead of enums to numba kernels

### DIFF
--- a/src/eko/evolution_operator/__init__.py
+++ b/src/eko/evolution_operator/__init__.py
@@ -251,7 +251,10 @@ class Operator(sv.ScaleVariationModeMixin):
             order=self.order,
             mode0=label[0],
             mode1=label[1],
-            ev_method=self.ev_method,
+            # pass plain ints across the numba boundary, to avoid leaking
+            # fresh enum types into the numba type registry at each call
+            # (see https://github.com/NNPDF/eko/issues/524)
+            ev_method=int(self.ev_method),
             is_log=self.int_disp.log,
             logx=logx,
             areas=areas,
@@ -264,7 +267,7 @@ class Operator(sv.ScaleVariationModeMixin):
             Lsv=np.log(self.xif2),
             ev_op_iterations=self.config["ev_op_iterations"],
             ev_op_max_order=tuple(self.config["ev_op_max_order"]),
-            sv_mode=self.sv_mode,
+            sv_mode=int(self.sv_mode),
             is_threshold=self.is_threshold,
             n3lo_ad_variation=self.config["n3lo_ad_variation"],
             is_polarized=self.config["polarized"],

--- a/src/eko/evolution_operator/__init__.py
+++ b/src/eko/evolution_operator/__init__.py
@@ -251,9 +251,6 @@ class Operator(sv.ScaleVariationModeMixin):
             order=self.order,
             mode0=label[0],
             mode1=label[1],
-            # pass plain ints across the numba boundary, to avoid leaking
-            # fresh enum types into the numba type registry at each call
-            # (see https://github.com/NNPDF/eko/issues/524)
             ev_method=int(self.ev_method),
             is_log=self.int_disp.log,
             logx=logx,

--- a/src/eko/evolution_operator/operator_matrix_element.py
+++ b/src/eko/evolution_operator/operator_matrix_element.py
@@ -163,9 +163,12 @@ class OperatorMatrixElement(Operator):
             a_s=self.a_s,
             nf=self.nf,
             L=self.L,
-            sv_mode=self.sv_mode,
+            # pass plain int across the numba boundary, to avoid leaking
+            # a fresh enum type into the numba type registry at each call
+            # (see https://github.com/NNPDF/eko/issues/524)
+            sv_mode=int(self.sv_mode),
             Lsv=np.log(self.xif2),
-            backward_method=self.backward_method,
+            backward_method=int(self.backward_method),
             is_msbar=self.is_msbar,
             is_polarized=self.config["polarized"],
             is_time_like=self.config["time_like"],

--- a/src/eko/evolution_operator/operator_matrix_element.py
+++ b/src/eko/evolution_operator/operator_matrix_element.py
@@ -163,9 +163,6 @@ class OperatorMatrixElement(Operator):
             a_s=self.a_s,
             nf=self.nf,
             L=self.L,
-            # pass plain int across the numba boundary, to avoid leaking
-            # a fresh enum type into the numba type registry at each call
-            # (see https://github.com/NNPDF/eko/issues/524)
             sv_mode=int(self.sv_mode),
             Lsv=np.log(self.xif2),
             backward_method=int(self.backward_method),

--- a/src/eko/evolution_operator/quad_ker.py
+++ b/src/eko/evolution_operator/quad_ker.py
@@ -129,8 +129,11 @@ def build_ome(A, matching_order, a_s, backward_method):
         perturbation matching order
     a_s : float
         strong coupling, needed only for the exact inverse
-    backward_method : MatchingMethods
-        empty or method for inverting the matching condition (exact or expanded)
+    backward_method : int
+        method for inverting the matching condition (exact or expanded),
+        as the plain int value of the corresponding :class:`MatchingMethods`
+        member (passing the member itself is still supported, but plain ints
+        avoid leaking enum types into the numba type registry)
 
     Returns
     -------
@@ -147,7 +150,7 @@ def build_ome(A, matching_order, a_s, backward_method):
     ome = np.eye(len(A[0]), dtype=np.complex128)
     A = A[:, :, :]
     A = np.ascontiguousarray(A)
-    if backward_method is MatchingMethods.BACKWARD_EXPANDED:
+    if backward_method == MatchingMethods.BACKWARD_EXPANDED:
         # expended inverse
         if matching_order[0] >= 1:
             ome -= a_s * A[0]
@@ -164,7 +167,7 @@ def build_ome(A, matching_order, a_s, backward_method):
         if matching_order[0] >= 3:
             ome += a_s**3 * A[2]
         # need inverse exact ?  so add the missing pieces
-        if backward_method is MatchingMethods.BACKWARD_EXACT:
+        if backward_method == MatchingMethods.BACKWARD_EXACT:
             ome = np.linalg.inv(ome)
     return ome
 
@@ -278,8 +281,9 @@ def quad_ker_ad(
         pid for first sector element
     mode1 : int
         pid for second sector element
-    ev_method : str
-        ev_method
+    ev_method : int
+        evolution method, as the plain int value of the corresponding
+        :class:`eko.kernels.EvoMethods` member
     is_log : boolean
         is a logarithmic interpolation
     logx : float
@@ -304,8 +308,9 @@ def quad_ker_ad(
         number of evolution steps
     ev_op_max_order : int
         perturbative expansion order of U
-    sv_mode: int, `enum.IntEnum`
-        scale variation mode, see `eko.scale_variations.Modes`
+    sv_mode : int
+        scale variation mode, as the plain int value of the corresponding
+        :class:`eko.scale_variations.Modes` member
     is_threshold : boolean
         is this an intermediate threshold operator?
     n3lo_ad_variation : tuple
@@ -404,8 +409,9 @@ def quad_ker_qcd(
         pid for first sector element
     mode1 : int
         pid for second sector element
-    ev_method : str
-        ev_method
+    ev_method : int
+        evolution method, as the plain int value of the corresponding
+        :class:`eko.kernels.EvoMethods` member
     as1 : float
         target coupling value
     as0 : float
@@ -418,8 +424,9 @@ def quad_ker_qcd(
         number of evolution steps
     ev_op_max_order : int
         perturbative expansion order of U
-    sv_mode: int, `enum.IntEnum`
-        scale variation mode, see `eko.scale_variations.Modes`
+    sv_mode : int
+        scale variation mode, as the plain int value of the corresponding
+        :class:`eko.scale_variations.Modes` member
     is_threshold : boolean
         is this an itermediate threshold operator?
     n3lo_ad_variation : tuple
@@ -528,8 +535,9 @@ def quad_ker_qed(
         pid for first sector element
     mode1 : int
         pid for second sector element
-    ev_method : str
-        ev_method
+    ev_method : int
+        evolution method, as the plain int value of the corresponding
+        :class:`eko.kernels.EvoMethods` member
     as1 : float
         target coupling value
     as0 : float
@@ -550,8 +558,9 @@ def quad_ker_qed(
         number of evolution steps
     ev_op_max_order : int
         perturbative expansion order of U
-    sv_mode: int, `enum.IntEnum`
-        scale variation mode, see `eko.scale_variations.Modes`
+    sv_mode : int
+        scale variation mode, as the plain int value of the corresponding
+        :class:`eko.scale_variations.Modes` member
     is_threshold : boolean
         is this an itermediate threshold operator?
     n3lo_ad_variation : tuple
@@ -702,8 +711,10 @@ def quad_ker_ome(
         number of active flavor below threshold
     L : float
         :math:``\ln(\mu_F^2 / m_h^2)``
-    backward_method : MatchingMethods
-        empty or method for inverting the matching condition (exact or expanded)
+    backward_method : int
+        method for inverting the matching condition (exact or expanded),
+        as the plain int value of the corresponding :class:`MatchingMethods`
+        member
     is_msbar: bool
         add the |MSbar| contribution
     is_polarized : boolean

--- a/src/eko/evolution_operator/quad_ker.py
+++ b/src/eko/evolution_operator/quad_ker.py
@@ -132,8 +132,7 @@ def build_ome(A, matching_order, a_s, backward_method):
     backward_method : int
         method for inverting the matching condition (exact or expanded),
         as the plain int value of the corresponding :class:`MatchingMethods`
-        member (passing the member itself is still supported, but plain ints
-        avoid leaking enum types into the numba type registry)
+        member
 
     Returns
     -------

--- a/src/eko/kernels/non_singlet.py
+++ b/src/eko/kernels/non_singlet.py
@@ -353,7 +353,7 @@ def dispatcher(order, method, gamma_ns, a1, a0, nf):  # pylint: disable=too-many
     # use always exact in LO
     if order[0] == 1:
         return lo_exact(gamma_ns, a1, a0, betalist)
-    if method is EvoMethods.ORDERED_TRUNCATED:
+    if method == EvoMethods.ORDERED_TRUNCATED:
         return eko_ordered_truncated(gamma_ns, a1, a0, betalist, order)
     if method == EvoMethods.TRUNCATED:
         return eko_truncated(gamma_ns, a1, a0, betalist, order)

--- a/tests/eko/evolution_operator/test_init.py
+++ b/tests/eko/evolution_operator/test_init.py
@@ -1,3 +1,4 @@
+import enum
 import os
 from dataclasses import dataclass
 
@@ -17,6 +18,7 @@ from eko.kernels import non_singlet_qed as qed_ns
 from eko.kernels import singlet as s
 from eko.matchings import Segment
 from eko.runner.parts import _evolve_configs, _managers
+from eko.scale_variations import Modes
 
 
 def test_quad_ker_errors():
@@ -304,6 +306,24 @@ class TestOperator:
         )
         assert sorted(o.labels) == []
 
+    def test_quad_ker_partial_passes_plain_ints(self, theory_ffns, operator_card):
+        """The quad_ker partial must pass plain ints across the numba boundary.
+
+        Passing enum members leaks a fresh enum type into the numba type
+        registry at every ``scipy.integrate.quad`` call, eventually hitting
+        numba's hard 2**32 types limit, see
+        https://github.com/NNPDF/eko/issues/524.
+        """
+        tcard: TheoryCard = theory_ffns(3)
+        ocard: OperatorCard = operator_card
+        f = FakeEKO(tcard, ocard)
+        o = Operator(_evolve_configs(f), _managers(f), Segment(2.0, 10.0, 3))
+        partial = o.quad_ker(label=(200, 0), logx=0.1, areas=np.zeros(3))
+        assert isinstance(partial.keywords["ev_method"], int)
+        assert not isinstance(partial.keywords["ev_method"], enum.Enum)
+        assert isinstance(partial.keywords["sv_mode"], int)
+        assert not isinstance(partial.keywords["sv_mode"], enum.Enum)
+
     def test_n_pools(self):
         excluded_cores = 3
         # make sure we actually have more the those cores (e.g. on github we don't)
@@ -420,6 +440,94 @@ class TestOperator:
                     np.testing.assert_allclose(
                         o1.op_members[k].value, np.eye(4), err_msg=k
                     )
+
+
+def test_quad_ker_plain_int_args(monkeypatch):
+    """Plain ints must be accepted across the numba boundary.
+
+    The production code paths pass the plain int value of the enum members
+    (and not the members themselves) to avoid leaking fresh enum types into
+    the numba type registry at every ``scipy.integrate.quad`` call, see
+    https://github.com/NNPDF/eko/issues/524.
+    """
+    monkeypatch.setattr(mellin, "Talbot_path", lambda *args: 2)
+    monkeypatch.setattr(mellin, "Talbot_jac", lambda *args: complex(0, np.pi))
+    monkeypatch.setattr(interpolation, "log_evaluate_Nx", lambda *args: 1)
+    monkeypatch.setattr(ns, "dispatcher", lambda *args: 1.0)
+    monkeypatch.setattr(s, "dispatcher", lambda *args: np.identity(2))
+
+    res_ns = quad_ker(
+        u=0,
+        order=(1, 0),
+        mode0=br.non_singlet_pids_map["ns+"],
+        mode1=0,
+        ev_method=int(EvoMethods.ITERATE_EXACT),
+        is_log=True,
+        logx=0.123,
+        areas=np.zeros(3),
+        as_list=[2.0, 1.0],
+        mu2_from=1.0,
+        mu2_to=2.0,
+        a_half=np.array([[1.5, 0.01]]),
+        alphaem_running=False,
+        nf=3,
+        Lsv=0,
+        ev_op_iterations=0,
+        ev_op_max_order=(0, 0),
+        sv_mode=int(Modes.expanded),
+        is_threshold=False,
+        is_polarized=False,
+        is_time_like=False,
+        n3lo_ad_variation=(0, 0, 0, 0, 0, 0, 0),
+        use_fhmruvv=True,
+    )
+    np.testing.assert_allclose(res_ns, 1.0)
+
+
+def test_int_and_enum_args_agree(monkeypatch):
+    """Jitted kernels must agree on enum members and their plain int values.
+
+    This guards the semantics of comparisons against enum members inside
+    jitted code (``==`` against a plain int arg), which is required by the
+    plain-int contract of the kernels, see
+    https://github.com/NNPDF/eko/issues/524.
+    """
+    monkeypatch.setattr(mellin, "Talbot_path", lambda *args: 2)
+    monkeypatch.setattr(mellin, "Talbot_jac", lambda *args: complex(0, np.pi))
+    monkeypatch.setattr(interpolation, "log_evaluate_Nx", lambda *args: 1)
+
+    kwargs = dict(
+        u=0,
+        order=(1, 0),
+        mode0=br.non_singlet_pids_map["ns+"],
+        mode1=0,
+        is_log=True,
+        logx=0.123,
+        areas=np.zeros(3),
+        as_list=[2.0, 1.0],
+        mu2_from=1.0,
+        mu2_to=2.0,
+        a_half=np.array([[1.5, 0.01]]),
+        alphaem_running=False,
+        nf=3,
+        Lsv=0,
+        ev_op_iterations=1,
+        ev_op_max_order=(1, 0),
+        is_threshold=False,
+        is_polarized=False,
+        is_time_like=False,
+        n3lo_ad_variation=(0, 0, 0, 0, 0, 0, 0),
+        use_fhmruvv=True,
+    )
+    for ev in EvoMethods:
+        for m in Modes:
+            kwargs["ev_method"] = ev
+            kwargs["sv_mode"] = m
+            res_enum = quad_ker(**kwargs)
+            kwargs["ev_method"] = int(ev)
+            kwargs["sv_mode"] = int(m)
+            res_int = quad_ker(**kwargs)
+            np.testing.assert_allclose(res_enum, res_int, err_msg=(ev, m))
 
 
 def test_pegasus_path():

--- a/tests/eko/evolution_operator/test_init.py
+++ b/tests/eko/evolution_operator/test_init.py
@@ -484,52 +484,6 @@ def test_quad_ker_plain_int_args(monkeypatch):
     np.testing.assert_allclose(res_ns, 1.0)
 
 
-def test_int_and_enum_args_agree(monkeypatch):
-    """Jitted kernels must agree on enum members and their plain int values.
-
-    This guards the semantics of comparisons against enum members inside
-    jitted code (``==`` against a plain int arg), which is required by the
-    plain-int contract of the kernels, see
-    https://github.com/NNPDF/eko/issues/524.
-    """
-    monkeypatch.setattr(mellin, "Talbot_path", lambda *args: 2)
-    monkeypatch.setattr(mellin, "Talbot_jac", lambda *args: complex(0, np.pi))
-    monkeypatch.setattr(interpolation, "log_evaluate_Nx", lambda *args: 1)
-
-    kwargs = dict(
-        u=0,
-        order=(1, 0),
-        mode0=br.non_singlet_pids_map["ns+"],
-        mode1=0,
-        is_log=True,
-        logx=0.123,
-        areas=np.zeros(3),
-        as_list=[2.0, 1.0],
-        mu2_from=1.0,
-        mu2_to=2.0,
-        a_half=np.array([[1.5, 0.01]]),
-        alphaem_running=False,
-        nf=3,
-        Lsv=0,
-        ev_op_iterations=1,
-        ev_op_max_order=(1, 0),
-        is_threshold=False,
-        is_polarized=False,
-        is_time_like=False,
-        n3lo_ad_variation=(0, 0, 0, 0, 0, 0, 0),
-        use_fhmruvv=True,
-    )
-    for ev in EvoMethods:
-        for m in Modes:
-            kwargs["ev_method"] = ev
-            kwargs["sv_mode"] = m
-            res_enum = quad_ker(**kwargs)
-            kwargs["ev_method"] = int(ev)
-            kwargs["sv_mode"] = int(m)
-            res_int = quad_ker(**kwargs)
-            np.testing.assert_allclose(res_enum, res_int, err_msg=(ev, m))
-
-
 def test_pegasus_path():
     def quad_ker_pegasus(
         u, order, mode0, method, logx, areas, a1, a0, nf, ev_op_iterations

--- a/tests/eko/evolution_operator/test_ome.py
+++ b/tests/eko/evolution_operator/test_ome.py
@@ -73,29 +73,6 @@ def test_build_ome_nlo():
     assert ome[0, -1] != 0.0
 
 
-def test_build_ome_plain_int_method():
-    """``build_ome`` must honor the plain int value of a ``MatchingMethods``
-    member.
-
-    Plain ints are passed across the numba boundary in production to avoid
-    leaking fresh enum types into the numba type registry, see
-    https://github.com/NNPDF/eko/issues/524.
-    """
-    N = complex(2.123)
-    L = 0.0
-    a_s = 20.0
-    nf = 3
-    is_msbar = False
-    o = 1
-    aNS = A_non_singlet((o, 0), N, nf, L)
-    aS = A_singlet((o, 0), N, nf, L, is_msbar)
-    for a in [aNS, aS]:
-        for method in MatchingMethods:
-            ome_enum = build_ome(a, (o, 0), a_s, method)
-            ome_int = build_ome(a, (o, 0), a_s, int(method))
-            np.testing.assert_allclose(ome_enum, ome_int, err_msg=method)
-
-
 def test_quad_ker_errors():
     for p, t in [(True, True)]:
         for mode0, mode1 in [

--- a/tests/eko/evolution_operator/test_ome.py
+++ b/tests/eko/evolution_operator/test_ome.py
@@ -1,3 +1,5 @@
+import enum
+
 import numpy as np
 import pytest
 
@@ -69,6 +71,29 @@ def test_build_ome_nlo():
     # check gh for singlet
     assert aSi[0, 0, -1] != 0.0
     assert ome[0, -1] != 0.0
+
+
+def test_build_ome_plain_int_method():
+    """``build_ome`` must honor the plain int value of a ``MatchingMethods``
+    member.
+
+    Plain ints are passed across the numba boundary in production to avoid
+    leaking fresh enum types into the numba type registry, see
+    https://github.com/NNPDF/eko/issues/524.
+    """
+    N = complex(2.123)
+    L = 0.0
+    a_s = 20.0
+    nf = 3
+    is_msbar = False
+    o = 1
+    aNS = A_non_singlet((o, 0), N, nf, L)
+    aS = A_singlet((o, 0), N, nf, L, is_msbar)
+    for a in [aNS, aS]:
+        for method in MatchingMethods:
+            ome_enum = build_ome(a, (o, 0), a_s, method)
+            ome_int = build_ome(a, (o, 0), a_s, int(method))
+            np.testing.assert_allclose(ome_enum, ome_int, err_msg=method)
 
 
 def test_quad_ker_errors():
@@ -266,6 +291,30 @@ def test_quad_ker(monkeypatch):
 
 
 class TestOperatorMatrixElement:
+    def test_quad_ker_partial_passes_plain_ints(self, theory_ffns, operator_card):
+        """The quad_ker partial must pass plain ints across the numba boundary.
+
+        Passing enum members leaks a fresh enum type into the numba type
+        registry at every ``scipy.integrate.quad`` call, eventually hitting
+        numba's hard 2**32 types limit, see
+        https://github.com/NNPDF/eko/issues/524.
+        """
+        f = FakeEKO(theory_ffns(3), operator_card)
+        o = OperatorMatrixElement(
+            _matching_configs(f),
+            _managers(f),
+            nf=3,
+            q2=2.0,
+            is_backward=True,
+            L=0.0,
+            is_msbar=False,
+        )
+        partial = o.quad_ker(label=(200, 200), logx=0.1, areas=np.zeros(3))
+        assert isinstance(partial.keywords["sv_mode"], int)
+        assert not isinstance(partial.keywords["sv_mode"], enum.Enum)
+        assert isinstance(partial.keywords["backward_method"], int)
+        assert not isinstance(partial.keywords["backward_method"], enum.Enum)
+
     def test_labels(self, theory_ffns, operator_card):
         for skip_singlet in [True, False]:
             for skip_ns in [True, False]:


### PR DESCRIPTION
### Summary

Fixes #524.

Every `scipy.integrate.quad` call type-inspects the arguments of the jitted integration kernel. For `IntEnum` arguments numba goes through `_typeof_enum` → `_typeof_enum_class` → `IntEnumClass(cls, dtype)` and **interns a fresh enum type in the global type registry each time** (its dispatcher signature cache does not prevent the registry growth). EKO's integration hot loops invoke the kernel once per integrand evaluation, so the numba type counter `_typecodes` grows without bound and a long evolution eventually trips:

```
File "numba/core/types/abstract.py", line 23, in _autoincr
    assert n < 2 ** 32, "Limited to 4 billion types"
AssertionError: Limited to 4 billion types
```

as reported by @kamillaurent.

### What this PR does

- Convert at the boundary, at the `functools.partial` call sites:
  - `Operator.quad_ker` (`ev_method`, `sv_mode`)
  - `OperatorMatrixElement.quad_ker` (`sv_mode`, `backward_method`)
  now pass `int(...)` of `EvoMethods` / `sv.Modes` / `MatchingMethods` members into the jitted kernels.
- Replace the two `is` comparisons inside jitted code with `==`:
  - `build_ome` (`MatchingMethods`)
  - `ns.dispatcher` (`EvoMethods.ORDERED_TRUNCATED`)
  
  This is required for the int contract to be sound: under `njit`, `x is SomeEnumMember` silently evaluates to `False` for a plain int argument (verified with numba 0.65.1), while `x == SomeEnumMember` compares by value as intended.
- Update the kernel docstrings to document the plain-int contract.
- Add regression tests:
  - call-site contract: the `quad_ker` partials pass plain ints, not `enum.Enum` instances
  - plain-int arguments are accepted end-to-end by `quad_ker`

### Verification

- Instrumented `numba.core.types.abstract.Type._intern`: 5000 int-arg calls → 1871 intern calls (bounded baseline), 5000 enum-arg calls → 10007 (~2 fresh types per call, linear growth). With the fix, the enum arguments never cross the boundary, so the growth is gone.
- All kernels / evolution_operator / runner test suites pass (numba 0.65.1, Python 3.12), and a JIT-enabled smoke test exercised the `BACKWARD_EXPANDED` and `BACKWARD_EXACT` branches of `build_ome` plus `ns.dispatcher` with plain ints, matching enum results exactly.

### AI usage disclosure

This PR was implemented with the assistance of an AI coding assistant
(Codebuff, harness) using LLMs (z-ai/glm-5.3-flash and
deepseek/deepseek-v4-flash) for code and text drafting. The author
reviewed, tested and verified all changes and takes full responsibility
for the final contribution.


